### PR TITLE
fix: added utility module of platform compiled constants for python paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +623,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "toml",
+ "which",
 ]
 
 [[package]]
@@ -972,6 +979,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
+dependencies = [
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,6 +1209,12 @@ name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = "2.0"
 once_cell = "1.19"
 chrono = "0.4"
 indicatif = "0.18"
+which = "8.0.0"
 
 
 [dev-dependencies]

--- a/src/plugins/list.rs
+++ b/src/plugins/list.rs
@@ -9,7 +9,7 @@ pub fn list_plugins(_opts: &GlobalOpts) -> Result<(), String> {
         println!("There are no current plugins installed.");
         println!();
         println!("To install a plugin, run:");
-        println!("  {} plugins install <package>", "r2x".bold().cyan());
+        println!("  {} install <package>", "r2x".bold().cyan());
         return Ok(());
     }
 

--- a/src/python_bridge/mod.rs
+++ b/src/python_bridge/mod.rs
@@ -12,9 +12,11 @@ mod initialization;
 mod manifest_builder;
 mod package_loader;
 mod plugin_invoker;
+mod utils;
 
 pub use initialization::configure_python_venv;
 pub use initialization::Bridge;
+pub use utils::{PYTHON_BIN_DIR, PYTHON_EXE, PYTHON_LIB_DIR, SITE_PACKAGES};
 
 #[cfg(test)]
 mod tests {

--- a/src/python_bridge/utils.rs
+++ b/src/python_bridge/utils.rs
@@ -1,0 +1,25 @@
+//! Utility constants and functions for platform-specific Python venv path handling
+//!
+//! This module provides compile-time constants for directories and files that differ
+//! between Windows and Unix-like systems in Python virtual environments.
+
+/// The name of the library directory in a Python venv (e.g., "Lib" on Windows, "lib" on Unix)
+#[cfg(windows)]
+pub const PYTHON_LIB_DIR: &str = "Lib";
+#[cfg(not(windows))]
+pub const PYTHON_LIB_DIR: &str = "lib";
+
+/// The name of the binaries/scripts directory in a Python venv (e.g., "Scripts" on Windows, "bin" on Unix)
+#[cfg(windows)]
+pub const PYTHON_BIN_DIR: &str = "Scripts";
+#[cfg(not(windows))]
+pub const PYTHON_BIN_DIR: &str = "bin";
+
+/// The name of the Python executable in a venv (e.g., "python.exe" on Windows, "python" on Unix)
+#[cfg(windows)]
+pub const PYTHON_EXE: &str = "python.exe";
+#[cfg(not(windows))]
+pub const PYTHON_EXE: &str = "python";
+
+/// The subdirectory name for site-packages within the lib directory
+pub const SITE_PACKAGES: &str = "site-packages";


### PR DESCRIPTION
Debugging some of the python paths on windows again. The new approach here is to have platform specific compile time constants for finding the python executable, site-packages directory, and other subpaths of the virtual environment and building the paths from these constants instead of having conditionals in the application logic. I think we could extend this approach of compartmentalizing platform specific logic out of the main application flow to make the code more readable. (e.g. downloading and installing uv should be a simple platform compiled function, install_uv(), that gets imported into the main application flow.