### PR TITLE
refactor: audit fixes — typed ConfigError, NO_COLOR, #[expect], CLI UX

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,10 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
           rustflags: ""
+      - name: Setup uv & Python
+        uses: ./.github/actions/setup-uv-python
+        with:
+          python-version: "3.12"
       - name: Format check
         run: cargo fmt --all -- --check
       - name: Clippy
@@ -46,5 +50,9 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           rustflags: ""
+      - name: Setup uv & Python
+        uses: ./.github/actions/setup-uv-python
+        with:
+          python-version: "3.12"
       - name: Test
         run: cargo test --workspace --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,6 +951,7 @@ dependencies = [
  "dirs",
  "serde",
  "tempfile",
+ "thiserror 2.0.18",
  "toml",
  "which",
 ]

--- a/crates/r2x-ast/src/schema_extractor.rs
+++ b/crates/r2x-ast/src/schema_extractor.rs
@@ -553,7 +553,7 @@ pub fn parse_union_types_from_annotation(annotation: &str) -> Vec<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used)]
+#[expect(clippy::expect_used)]
 mod tests {
     use crate::schema_extractor::*;
 

--- a/crates/r2x-cli/src/commands/config.rs
+++ b/crates/r2x-cli/src/commands/config.rs
@@ -81,12 +81,8 @@ pub fn handle_config(action: Option<ConfigAction>, opts: GlobalOpts) {
     let action = if let Some(action) = action {
         action
     } else {
-        println!(
-            "{}",
-            "Tip: run `r2x config show` to inspect settings or `r2x config set <key> <value>` to update them."
-                .dimmed()
-        );
-        return;
+        // Default to show when no subcommand provided (like git config)
+        ConfigAction::Show
     };
 
     match action {
@@ -201,7 +197,10 @@ pub fn handle_config(action: Option<ConfigAction>, opts: GlobalOpts) {
                             | "log-max-size"
                     )
                 {
-                    config.set(&key, value.clone());
+                    if let Err(e) = config.set(&key, value.clone()) {
+                        logger::error(&format!("Failed to set config '{}': {}", key, e));
+                        return;
+                    }
                     match config.save() {
                         Ok(()) => {
                             logger::success(&format!("Set {} = {}", key, value));

--- a/crates/r2x-cli/src/commands/read.rs
+++ b/crates/r2x-cli/src/commands/read.rs
@@ -1522,8 +1522,7 @@ fn module_exists(python_exe: &str, module_name: &str) -> bool {
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
+        .is_ok_and(|status| status.success())
 }
 
 fn install_package_with_spinner(

--- a/crates/r2x-cli/src/commands/run/mod.rs
+++ b/crates/r2x-cli/src/commands/run/mod.rs
@@ -75,7 +75,7 @@ pub struct RunCommand {
     pub list: bool,
     #[arg(long)]
     pub print: bool,
-    #[arg(long)]
+    #[arg(short = 'n', long)]
     pub dry_run: bool,
     #[arg(short = 'o', long, value_name = "FILE")]
     pub output: Option<String>,

--- a/crates/r2x-cli/src/main.rs
+++ b/crates/r2x-cli/src/main.rs
@@ -114,6 +114,13 @@ fn exit_on_plugin_error(result: Result<(), r2x::plugins::error::PluginError>) {
 }
 
 fn main() {
+    // Respect NO_COLOR and TERM=dumb for accessibility and automation
+    if std::env::var_os("NO_COLOR").is_some()
+        || std::env::var("TERM").ok().as_deref() == Some("dumb")
+    {
+        colored::control::set_override(false);
+    }
+
     let cli = Cli::parse();
 
     let mut startup_config = match config_manager::Config::load() {

--- a/crates/r2x-cli/src/pipeline_config.rs
+++ b/crates/r2x-cli/src/pipeline_config.rs
@@ -273,7 +273,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::panic)] // panic is acceptable in test code for unreachable branches
+    #[expect(clippy::panic)] // panic is acceptable in test code for unreachable branches
     fn test_substitute_yaml_value() {
         let mut vars = HashMap::new();
         vars.insert("year".to_string(), serde_yaml::Value::Number(2032.into()));

--- a/crates/r2x-config/Cargo.toml
+++ b/crates/r2x-config/Cargo.toml
@@ -14,6 +14,7 @@ description = "Configuration management for the r2x CLI"
 [dependencies]
 dirs = "6.0"
 serde = { version = "1.0", features = ["derive"] }
+thiserror = "2"
 toml = { version = "0.9", features = ["preserve_order"] }
 which = "8.0.0"
 

--- a/crates/r2x-config/src/lib.rs
+++ b/crates/r2x-config/src/lib.rs
@@ -148,23 +148,38 @@ impl Config {
             "venv-path" => self.venv_path = Some(value),
             "r2x-core-version" => self.r2x_core_version = Some(value),
             "log-python" => {
-                self.log_python = Some(value.parse::<bool>().map_err(|_| ConfigError::InvalidValue {
-                    key: key.to_string(),
-                    message: format!("expected 'true' or 'false', got '{}'", value),
-                })?);
+                self.log_python =
+                    Some(
+                        value
+                            .parse::<bool>()
+                            .map_err(|_| ConfigError::InvalidValue {
+                                key: key.to_string(),
+                                message: format!("expected 'true' or 'false', got '{}'", value),
+                            })?,
+                    );
             }
             "no-stdout" => {
-                self.no_stdout = Some(value.parse::<bool>().map_err(|_| ConfigError::InvalidValue {
-                    key: key.to_string(),
-                    message: format!("expected 'true' or 'false', got '{}'", value),
-                })?);
+                self.no_stdout =
+                    Some(
+                        value
+                            .parse::<bool>()
+                            .map_err(|_| ConfigError::InvalidValue {
+                                key: key.to_string(),
+                                message: format!("expected 'true' or 'false', got '{}'", value),
+                            })?,
+                    );
             }
             "log-path" => self.log_path = Some(value),
             "log-max-size" => {
-                self.log_max_size = Some(value.parse::<u64>().map_err(|_| ConfigError::InvalidValue {
-                    key: key.to_string(),
-                    message: format!("expected a positive integer, got '{}'", value),
-                })?);
+                self.log_max_size =
+                    Some(
+                        value
+                            .parse::<u64>()
+                            .map_err(|_| ConfigError::InvalidValue {
+                                key: key.to_string(),
+                                message: format!("expected a positive integer, got '{}'", value),
+                            })?,
+                    );
             }
             _ => return Err(ConfigError::UnknownKey(key.to_string())),
         }
@@ -372,7 +387,9 @@ impl Config {
             if let Ok(output) = Command::new("where.exe").arg("uv").output() {
                 if output.status.success() {
                     let path = String::from_utf8(output.stdout)
-                        .map_err(|e| ConfigError::UvNotFound(format!("Failed to parse uv path: {}", e)))?
+                        .map_err(|e| {
+                            ConfigError::UvNotFound(format!("Failed to parse uv path: {}", e))
+                        })?
                         .lines()
                         .next()
                         .unwrap_or("")
@@ -408,7 +425,9 @@ impl Config {
             if let Ok(output) = Command::new("which").arg("uv").output() {
                 if output.status.success() {
                     let path = String::from_utf8(output.stdout)
-                        .map_err(|e| ConfigError::UvNotFound(format!("Failed to parse uv path: {}", e)))?
+                        .map_err(|e| {
+                            ConfigError::UvNotFound(format!("Failed to parse uv path: {}", e))
+                        })?
                         .trim()
                         .to_string();
                     eprintln!("Found uv at: {}", path);
@@ -451,7 +470,10 @@ impl Config {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(ConfigError::VenvCreation(format!("Failed to create venv: {}", stderr)));
+            return Err(ConfigError::VenvCreation(format!(
+                "Failed to create venv: {}",
+                stderr
+            )));
         }
 
         Ok(venv_path)
@@ -511,7 +533,9 @@ mod tests {
     #[test]
     fn test_config_set_get_log_fields() {
         let mut config = Config::default();
-        assert!(config.set("log-path", "/tmp/r2x-custom.log".to_string()).is_ok());
+        assert!(config
+            .set("log-path", "/tmp/r2x-custom.log".to_string())
+            .is_ok());
         assert!(config.set("log-max-size", "1048576".to_string()).is_ok());
         assert_eq!(
             config.get("log-path"),

--- a/crates/r2x-config/src/lib.rs
+++ b/crates/r2x-config/src/lib.rs
@@ -512,7 +512,10 @@ mod tests {
         assert!(result.is_err());
         if let Err(err) = result {
             let msg = err.to_string();
-            assert!(msg.contains("unknown-key"), "error should mention the key: {msg}");
+            assert!(
+                msg.contains("unknown-key"),
+                "error should mention the key: {msg}"
+            );
         }
     }
 

--- a/crates/r2x-config/src/lib.rs
+++ b/crates/r2x-config/src/lib.rs
@@ -1,6 +1,42 @@
 pub mod venv_paths;
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+// =============================================================================
+// ConfigError - typed error for configuration operations
+// =============================================================================
+
+/// Errors that can occur during configuration operations
+#[derive(Error, Debug)]
+pub enum ConfigError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Failed to parse config TOML: {0}")]
+    TomlParse(#[from] toml::de::Error),
+
+    #[error("Failed to serialize config to TOML: {0}")]
+    TomlSerialize(#[from] toml::ser::Error),
+
+    #[error("uv not found: {0}")]
+    UvNotFound(String),
+
+    #[error("Failed to create venv: {0}")]
+    VenvCreation(String),
+
+    #[error("Unknown config key: '{0}'")]
+    UnknownKey(String),
+
+    #[error("Failed to parse config value for '{key}': {message}")]
+    InvalidValue { key: String, message: String },
+
+    #[error("Home directory not found")]
+    NoHomeDir,
+
+    #[error("Config directory not found")]
+    NoConfigDir,
+}
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
@@ -69,7 +105,7 @@ impl Config {
         default
     }
 
-    pub fn load() -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn load() -> Result<Self, ConfigError> {
         let path = Self::path();
         if path.exists() {
             let content = fs::read_to_string(&path)?;
@@ -79,7 +115,7 @@ impl Config {
         }
     }
 
-    pub fn save(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub fn save(&self) -> Result<(), ConfigError> {
         let path = Self::path();
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
@@ -104,19 +140,35 @@ impl Config {
         }
     }
 
-    pub fn set(&mut self, key: &str, value: String) {
+    pub fn set(&mut self, key: &str, value: String) -> Result<(), ConfigError> {
         match key {
             "cache-path" => self.cache_path = Some(value),
             "uv-path" => self.uv_path = Some(value),
             "python-version" => self.python_version = Some(value),
             "venv-path" => self.venv_path = Some(value),
             "r2x-core-version" => self.r2x_core_version = Some(value),
-            "log-python" => self.log_python = value.parse::<bool>().ok(),
-            "no-stdout" => self.no_stdout = value.parse::<bool>().ok(),
+            "log-python" => {
+                self.log_python = Some(value.parse::<bool>().map_err(|_| ConfigError::InvalidValue {
+                    key: key.to_string(),
+                    message: format!("expected 'true' or 'false', got '{}'", value),
+                })?);
+            }
+            "no-stdout" => {
+                self.no_stdout = Some(value.parse::<bool>().map_err(|_| ConfigError::InvalidValue {
+                    key: key.to_string(),
+                    message: format!("expected 'true' or 'false', got '{}'", value),
+                })?);
+            }
             "log-path" => self.log_path = Some(value),
-            "log-max-size" => self.log_max_size = value.parse::<u64>().ok(),
-            _ => {}
+            "log-max-size" => {
+                self.log_max_size = Some(value.parse::<u64>().map_err(|_| ConfigError::InvalidValue {
+                    key: key.to_string(),
+                    message: format!("expected a positive integer, got '{}'", value),
+                })?);
+            }
+            _ => return Err(ConfigError::UnknownKey(key.to_string())),
         }
+        Ok(())
     }
 
     pub fn is_empty(&self) -> bool {
@@ -163,7 +215,7 @@ impl Config {
         values
     }
 
-    pub fn reset() -> Result<(), Box<dyn std::error::Error>> {
+    pub fn reset() -> Result<(), ConfigError> {
         let path = Self::path();
         if path.exists() {
             fs::remove_file(&path)?;
@@ -276,7 +328,7 @@ impl Config {
         }
     }
 
-    pub fn ensure_uv_path(&mut self) -> Result<String, Box<dyn std::error::Error>> {
+    pub fn ensure_uv_path(&mut self) -> Result<String, ConfigError> {
         // Check if the stored path exists
         if let Some(ref path) = self.uv_path {
             if std::path::Path::new(path).exists() {
@@ -310,7 +362,7 @@ impl Config {
                 .status()?;
 
             if !status.success() {
-                return Err("Failed to install uv. Please install it manually from: https://docs.astral.sh/uv/getting-started/installation/".into());
+                return Err(ConfigError::UvNotFound("Failed to install uv. Please install it manually from: https://docs.astral.sh/uv/getting-started/installation/".to_string()));
             }
 
             eprintln!("\nuv installation completed. Verifying installation...");
@@ -319,7 +371,8 @@ impl Config {
             // Try to find it using where.exe
             if let Ok(output) = Command::new("where.exe").arg("uv").output() {
                 if output.status.success() {
-                    let path = String::from_utf8(output.stdout)?
+                    let path = String::from_utf8(output.stdout)
+                        .map_err(|e| ConfigError::UvNotFound(format!("Failed to parse uv path: {}", e)))?
                         .lines()
                         .next()
                         .unwrap_or("")
@@ -334,7 +387,7 @@ impl Config {
                 }
             }
 
-            return Err("Failed to locate uv after installation. Please add %USERPROFILE%\\.local\\bin to your PATH and restart your terminal".into());
+            return Err(ConfigError::UvNotFound("Failed to locate uv after installation. Please add %USERPROFILE%\\.local\\bin to your PATH and restart your terminal".to_string()));
         }
 
         #[cfg(not(target_os = "windows"))]
@@ -346,7 +399,7 @@ impl Config {
                 .status()?;
 
             if !status.success() {
-                return Err("Failed to install uv".into());
+                return Err(ConfigError::UvNotFound("Failed to install uv".to_string()));
             }
 
             eprintln!("\nuv installation completed. Verifying installation...");
@@ -354,7 +407,10 @@ impl Config {
             // Verify the installation
             if let Ok(output) = Command::new("which").arg("uv").output() {
                 if output.status.success() {
-                    let path = String::from_utf8(output.stdout)?.trim().to_string();
+                    let path = String::from_utf8(output.stdout)
+                        .map_err(|e| ConfigError::UvNotFound(format!("Failed to parse uv path: {}", e)))?
+                        .trim()
+                        .to_string();
                     eprintln!("Found uv at: {}", path);
                     self.uv_path = Some(path.clone());
                     self.save()?;
@@ -362,17 +418,17 @@ impl Config {
                 }
             }
 
-            Err("Failed to locate uv after installation. Verify that ~/.local/bin or ~/.cargo/bin is in your PATH".into())
+            Err(ConfigError::UvNotFound("Failed to locate uv after installation. Verify that ~/.local/bin or ~/.cargo/bin is in your PATH".to_string()))
         }
     }
 
-    pub fn ensure_cache_path(&mut self) -> Result<String, Box<dyn std::error::Error>> {
+    pub fn ensure_cache_path(&mut self) -> Result<String, ConfigError> {
         let cache_path = self.get_cache_path();
         fs::create_dir_all(&cache_path)?;
         Ok(cache_path)
     }
 
-    pub fn ensure_venv_path(&mut self) -> Result<String, Box<dyn std::error::Error>> {
+    pub fn ensure_venv_path(&mut self) -> Result<String, ConfigError> {
         use std::process::Command;
 
         let venv_path = self.get_venv_path();
@@ -395,7 +451,7 @@ impl Config {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(format!("Failed to create venv: {}", stderr).into());
+            return Err(ConfigError::VenvCreation(format!("Failed to create venv: {}", stderr)));
         }
 
         Ok(venv_path)
@@ -415,23 +471,24 @@ mod tests {
     #[test]
     fn test_config_set_get() {
         let mut config = Config::default();
-        config.set("cache-path", "test-value".to_string());
+        assert!(config.set("cache-path", "test-value".to_string()).is_ok());
         assert_eq!(config.get("cache-path"), Some("test-value".to_string()));
     }
 
     #[test]
     fn test_config_multiple_fields() {
         let mut config = Config::default();
-        config.set("cache-path", "/tmp/cache".to_string());
+        assert!(config.set("cache-path", "/tmp/cache".to_string()).is_ok());
         assert_eq!(config.get("cache-path"), Some("/tmp/cache".to_string()));
         assert!(!config.is_empty());
     }
 
     #[test]
-    fn test_config_unknown_key() {
+    fn test_config_unknown_key_returns_error() {
         let mut config = Config::default();
-        config.set("unknown-key", "value".to_string());
-        assert_eq!(config.get("unknown-key"), None);
+        let result = config.set("unknown-key", "value".to_string());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("unknown-key"));
     }
 
     #[test]
@@ -445,8 +502,8 @@ mod tests {
     #[test]
     fn test_config_set_get_bool_fields() {
         let mut config = Config::default();
-        config.set("no-stdout", "true".to_string());
-        config.set("log-python", "false".to_string());
+        assert!(config.set("no-stdout", "true".to_string()).is_ok());
+        assert!(config.set("log-python", "false".to_string()).is_ok());
         assert_eq!(config.get("no-stdout"), Some("true".to_string()));
         assert_eq!(config.get("log-python"), Some("false".to_string()));
     }
@@ -454,8 +511,8 @@ mod tests {
     #[test]
     fn test_config_set_get_log_fields() {
         let mut config = Config::default();
-        config.set("log-path", "/tmp/r2x-custom.log".to_string());
-        config.set("log-max-size", "1048576".to_string());
+        assert!(config.set("log-path", "/tmp/r2x-custom.log".to_string()).is_ok());
+        assert!(config.set("log-max-size", "1048576".to_string()).is_ok());
         assert_eq!(
             config.get("log-path"),
             Some("/tmp/r2x-custom.log".to_string())

--- a/crates/r2x-config/src/lib.rs
+++ b/crates/r2x-config/src/lib.rs
@@ -510,7 +510,10 @@ mod tests {
         let mut config = Config::default();
         let result = config.set("unknown-key", "value".to_string());
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("unknown-key"));
+        if let Err(err) = result {
+            let msg = err.to_string();
+            assert!(msg.contains("unknown-key"), "error should mention the key: {msg}");
+        }
     }
 
     #[test]

--- a/crates/r2x-manifest/src/package_discovery.rs
+++ b/crates/r2x-manifest/src/package_discovery.rs
@@ -8,7 +8,7 @@ use tracing::{debug, info};
 
 #[derive(Debug, Deserialize)]
 struct DirectUrlVcsInfo {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     vcs: String,
     #[serde(default)]
     requested_revision: Option<String>,

--- a/crates/r2x-python/src/plugin_upgrader.rs
+++ b/crates/r2x-python/src/plugin_upgrader.rs
@@ -11,7 +11,7 @@ use r2x_manifest::types::Plugin;
 use std::path::{Path, PathBuf};
 
 impl Bridge {
-    #[allow(clippy::unused_self)] // kept for API consistency with other invoke methods
+    #[expect(clippy::unused_self)] // kept for API consistency with other invoke methods
     pub(crate) fn invoke_upgrader_plugin(
         &self,
         target: &str,

--- a/crates/r2x-python/src/utils.rs
+++ b/crates/r2x-python/src/utils.rs
@@ -181,7 +181,6 @@ mod tests {
     use tempfile::TempDir;
 
     /// Helper to create a mock venv structure for testing
-    #[allow(dead_code)]
     fn create_mock_venv_unix(python_version: &str) -> Option<TempDir> {
         let temp_dir = TempDir::new().ok()?;
         let venv_path = temp_dir.path();
@@ -201,7 +200,7 @@ mod tests {
     }
 
     /// Helper to create a mock Windows venv structure for testing
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     fn create_mock_venv_windows() -> Option<TempDir> {
         let temp_dir = TempDir::new().ok()?;
         let venv_path = temp_dir.path();


### PR DESCRIPTION
## Summary

Addresses audit findings against **rust-developer**, **good-api**, and **cli-ux** skills.

### Rust Developer fixes
- **Typed errors**: Replace `Box<dyn std::error::Error>` with `ConfigError` (thiserror) in `r2x-config` crate — 9 typed variants replacing opaque error type
- **Config::set() now returns Result**: Unknown config keys are rejected with `ConfigError::UnknownKey` instead of silent no-op
- **#[allow] → #[expect]**: 5 files converted; pre-existing clippy `map_unwrap_or` fixed in read.rs

### CLI-UX fixes
- **NO_COLOR / TERM=dumb**: Checked at startup; disables colored output for accessibility/automation
- **--dry-run -n**: Added conventional short flag
- **r2x config defaults to show**: Like `git config`, no-args now shows configuration

### Verification
- Clippy: clean across workspace (`-D warnings`)
- Tests: 232 passed, 0 failed
- 12 files changed, +106/-43 lines