### PR TITLE
Improve direct plugin CLI UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,17 @@ r2x run pipeline.yaml my-pipeline -o output.json
 Skip the pipeline and run a single plugin with inline arguments:
 
 ```bash
-# Run a plugin directly
-r2x run plugin r2x-reeds.reeds-parser solve_year=2030 weather_year=2012
+# Run a plugin directly with idiomatic flags
+r2x run plugin r2x-reeds.reeds-parser \
+  --path /path/to/reeds/run \
+  --solve-year 2030 \
+  --weather-year 2012
+
+# Existing key=value arguments also work
+r2x run plugin r2x-reeds.reeds-parser \
+  path=/path/to/reeds/run \
+  solve_year=2030 \
+  weather_year=2012
 
 # Show a plugin's help
 r2x run plugin r2x-reeds.reeds-parser --show-help

--- a/crates/r2x-cli/src/commands/run/plugin.rs
+++ b/crates/r2x-cli/src/commands/run/plugin.rs
@@ -7,8 +7,10 @@ use colored::Colorize;
 use r2x_logger as logger;
 use r2x_manifest::runtime::build_runtime_bindings;
 use r2x_manifest::types::Manifest;
+use r2x_manifest::types::Plugin;
 use r2x_python::plugin_invoker::PluginInvocationResult;
 use r2x_python::python_bridge::Bridge;
+use std::collections::BTreeSet;
 use std::time::{Duration, Instant};
 
 pub(super) fn handle_plugin_command(cmd: PluginCommand, opts: &GlobalOpts) -> Result<(), RunError> {
@@ -75,7 +77,8 @@ fn run_plugin(
     package_verification::verify_and_ensure_plugin(&manifest, plugin_name)
         .map_err(|e| RunError::Verification(e.to_string()))?;
 
-    let config_map = parse_plugin_args(args)?;
+    let argument_spec = PluginArgumentSpec::from_plugin(plugin_name, plugin);
+    let config_map = parse_plugin_args(args, &argument_spec)?;
     let config_json = serde_json::to_string(&config_map)
         .map_err(|e| RunError::Config(format!("Failed to serialize config: {}", e)))?;
 
@@ -179,25 +182,274 @@ fn run_plugin(
     Ok(())
 }
 
-fn parse_plugin_args(args: &[String]) -> Result<serde_json::Value, RunError> {
-    let mut config = serde_json::json!({});
+#[derive(Debug)]
+struct PluginArgumentSpec {
+    plugin_name: String,
+    known_keys: BTreeSet<String>,
+    required_keys: BTreeSet<String>,
+}
 
-    for arg in args {
-        if let Some(eq_pos) = arg.find('=') {
-            let key = &arg[..eq_pos];
-            let value_str = &arg[eq_pos + 1..];
-            let python_key = key.replace('-', "_");
-            let value = parse_json_value(value_str)?;
-            config[python_key] = value;
-        } else {
-            return Err(RunError::InvalidArgs(format!(
-                "Invalid argument format: '{}'. Expected key=value",
-                arg
-            )));
+impl PluginArgumentSpec {
+    fn from_plugin(plugin_name: &str, plugin: &Plugin) -> Self {
+        let mut known_keys = BTreeSet::new();
+        let mut required_keys = BTreeSet::new();
+
+        let config_is_constructed = plugin.config_class.is_some() && plugin.config_module.is_some();
+        for param in &plugin.parameters {
+            let key = canonical_key(param.name.as_ref());
+            known_keys.insert(key.clone());
+            if is_store_like_param(&key) {
+                known_keys.extend([
+                    "path".to_string(),
+                    "store_path".to_string(),
+                    "store".to_string(),
+                ]);
+            }
+            if param.required
+                && param.default.is_none()
+                && !(config_is_constructed && key == "config")
+                && !is_store_like_param(&key)
+            {
+                required_keys.insert(key);
+            }
+        }
+
+        for (field_name, field) in plugin.config_schema.iter() {
+            let key = canonical_key(field_name.as_ref());
+            known_keys.insert(key.clone());
+            if field.required && field.default.is_none() {
+                required_keys.insert(key);
+            }
+        }
+
+        Self {
+            plugin_name: plugin_name.to_string(),
+            known_keys,
+            required_keys,
         }
     }
 
+    #[cfg(test)]
+    fn for_test(plugin_name: &str, known_keys: &[&str], required_keys: &[&str]) -> Self {
+        Self {
+            plugin_name: plugin_name.to_string(),
+            known_keys: known_keys.iter().map(|key| canonical_key(key)).collect(),
+            required_keys: required_keys.iter().map(|key| canonical_key(key)).collect(),
+        }
+    }
+
+    fn validate_flag_key(&self, original: &str, key: &str) -> Result<(), RunError> {
+        if self.known_keys.is_empty() || self.known_keys.contains(key) {
+            return Ok(());
+        }
+
+        let mut message = format!("unknown option '--{}'", original);
+        if let Some(suggestion) = self.suggest_flag(original) {
+            message.push_str(&format!("\n\nDid you mean '--{}'?", suggestion));
+        }
+        message.push_str(&format!("\n\nTry:\n  {}", self.example_command()));
+        Err(RunError::InvalidArgs(message))
+    }
+
+    fn validate_required_keys(&self, config: &serde_json::Value) -> Result<(), RunError> {
+        if self.required_keys.is_empty() {
+            return Ok(());
+        }
+
+        let missing: Vec<String> = self
+            .required_keys
+            .iter()
+            .filter(|key| config.get(key.as_str()).is_none())
+            .map(|key| format!("--{}", cli_flag_name(key)))
+            .collect();
+        if missing.is_empty() {
+            return Ok(());
+        }
+
+        Err(RunError::InvalidArgs(format!(
+            "missing required plugin option(s): {}\n\nTry:\n  {}",
+            missing.join(", "),
+            self.example_command()
+        )))
+    }
+
+    fn suggest_flag(&self, original: &str) -> Option<String> {
+        let requested = canonical_key(original);
+        self.known_keys
+            .iter()
+            .filter_map(|key| {
+                let distance = edit_distance(&requested, key);
+                if distance <= 3 {
+                    Some((distance, cli_flag_name(key)))
+                } else {
+                    None
+                }
+            })
+            .min_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)))
+            .map(|(_, flag)| flag)
+    }
+
+    fn example_command(&self) -> String {
+        let mut command = format!("r2x run plugin {}", self.plugin_name);
+        if self.required_keys.is_empty() {
+            if let Some(key) = self.known_keys.iter().next() {
+                command.push_str(&format!(" --{} <value>", cli_flag_name(key)));
+            } else {
+                command.push_str(" [OPTIONS]");
+            }
+            return command;
+        }
+
+        for key in &self.required_keys {
+            command.push_str(&format!(" --{} <value>", cli_flag_name(key)));
+        }
+        command
+    }
+}
+
+fn parse_plugin_args(
+    args: &[String],
+    argument_spec: &PluginArgumentSpec,
+) -> Result<serde_json::Value, RunError> {
+    let mut config = serde_json::json!({});
+    let mut index = 0;
+
+    while index < args.len() {
+        let arg = &args[index];
+        if arg == "--set" {
+            let Some(next_arg) = args.get(index + 1) else {
+                return Err(RunError::InvalidArgs(
+                    "--set requires a key=value argument".to_string(),
+                ));
+            };
+            insert_key_value_arg(next_arg, &mut config, argument_spec, true)?;
+            index += 2;
+            continue;
+        }
+
+        if let Some(set_arg) = arg.strip_prefix("--set=") {
+            insert_key_value_arg(set_arg, &mut config, argument_spec, true)?;
+            index += 1;
+            continue;
+        }
+
+        if let Some(flag_arg) = arg.strip_prefix("--") {
+            parse_flag_arg(flag_arg, args, &mut index, &mut config, argument_spec)?;
+            continue;
+        }
+
+        if arg.contains('=') {
+            insert_key_value_arg(arg, &mut config, argument_spec, false)?;
+            index += 1;
+            continue;
+        }
+
+        return Err(RunError::InvalidArgs(format!(
+            "unexpected positional argument '{}'. Use --<option> <value> or key=value",
+            arg
+        )));
+    }
+
+    argument_spec.validate_required_keys(&config)?;
     Ok(config)
+}
+
+fn parse_flag_arg(
+    flag_arg: &str,
+    args: &[String],
+    index: &mut usize,
+    config: &mut serde_json::Value,
+    argument_spec: &PluginArgumentSpec,
+) -> Result<(), RunError> {
+    if flag_arg.is_empty() {
+        return Err(RunError::InvalidArgs(
+            "empty option '--' is not supported".to_string(),
+        ));
+    }
+
+    let (raw_key, value_str) = if let Some(eq_pos) = flag_arg.find('=') {
+        (&flag_arg[..eq_pos], &flag_arg[eq_pos + 1..])
+    } else {
+        let Some(next_arg) = args.get(*index + 1) else {
+            return Err(RunError::InvalidArgs(format!(
+                "option '--{}' requires a value",
+                flag_arg
+            )));
+        };
+        if next_arg.starts_with("--") {
+            return Err(RunError::InvalidArgs(format!(
+                "option '--{}' requires a value",
+                flag_arg
+            )));
+        }
+        (flag_arg, next_arg.as_str())
+    };
+
+    let key = canonical_key(raw_key);
+    argument_spec.validate_flag_key(raw_key, &key)?;
+    config[key] = parse_json_value(value_str)?;
+    *index += if flag_arg.contains('=') { 1 } else { 2 };
+    Ok(())
+}
+
+fn insert_key_value_arg(
+    arg: &str,
+    config: &mut serde_json::Value,
+    argument_spec: &PluginArgumentSpec,
+    validate_key: bool,
+) -> Result<(), RunError> {
+    let Some(eq_pos) = arg.find('=') else {
+        return Err(RunError::InvalidArgs(format!(
+            "Invalid argument format: '{}'. Expected key=value",
+            arg
+        )));
+    };
+
+    let raw_key = &arg[..eq_pos];
+    if raw_key.is_empty() {
+        return Err(RunError::InvalidArgs(format!(
+            "Invalid argument format: '{}'. Expected key=value",
+            arg
+        )));
+    }
+
+    let key = canonical_key(raw_key);
+    if validate_key {
+        argument_spec.validate_flag_key(raw_key, &key)?;
+    }
+    config[key] = parse_json_value(&arg[eq_pos + 1..])?;
+    Ok(())
+}
+
+fn canonical_key(key: &str) -> String {
+    key.trim_start_matches('-').replace('-', "_")
+}
+
+fn cli_flag_name(key: &str) -> String {
+    key.replace('_', "-")
+}
+
+fn is_store_like_param(key: &str) -> bool {
+    matches!(key, "store" | "data_store")
+}
+
+fn edit_distance(left: &str, right: &str) -> usize {
+    let right_chars: Vec<char> = right.chars().collect();
+    let mut previous: Vec<usize> = (0..=right_chars.len()).collect();
+    let mut current = vec![0; right_chars.len() + 1];
+
+    for (left_index, left_char) in left.chars().enumerate() {
+        current[0] = left_index + 1;
+        for (right_index, right_char) in right_chars.iter().enumerate() {
+            let substitution_cost = usize::from(left_char != *right_char);
+            current[right_index + 1] = (previous[right_index + 1] + 1)
+                .min(current[right_index] + 1)
+                .min(previous[right_index] + substitution_cost);
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+
+    previous[right_chars.len()]
 }
 
 fn parse_json_value(value_str: &str) -> Result<serde_json::Value, RunError> {
@@ -220,4 +472,125 @@ fn parse_json_value(value_str: &str) -> Result<serde_json::Value, RunError> {
     }
 
     Ok(serde_json::json!(value_str))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::commands::run::plugin::{parse_plugin_args, PluginArgumentSpec};
+
+    fn spec() -> PluginArgumentSpec {
+        PluginArgumentSpec::for_test(
+            "r2x-reeds.reeds-parser",
+            &["path", "weather_year", "solve_year", "enabled", "years"],
+            &["path", "weather_year", "solve_year"],
+        )
+    }
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn parses_plugin_flags_and_key_value_forms_to_same_config(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let expected = serde_json::json!({
+            "path": "/runs/reeds",
+            "weather_year": 2012,
+            "solve_year": 2025,
+        });
+
+        for candidate in [
+            args(&[
+                "--path",
+                "/runs/reeds",
+                "--weather-year",
+                "2012",
+                "--solve-year",
+                "2025",
+            ]),
+            args(&[
+                "--path=/runs/reeds",
+                "--weather-year=2012",
+                "--solve-year=2025",
+            ]),
+            args(&[
+                "--path",
+                "/runs/reeds",
+                "--weather_year",
+                "2012",
+                "--solve_year",
+                "2025",
+            ]),
+            args(&["path=/runs/reeds", "weather_year=2012", "solve_year=2025"]),
+            args(&[
+                "--set",
+                "path=/runs/reeds",
+                "--set",
+                "weather_year=2012",
+                "--set",
+                "solve_year=2025",
+            ]),
+        ] {
+            let parsed = parse_plugin_args(&candidate, &spec())?;
+            assert_eq!(parsed, expected);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn preserves_jsonish_value_parsing() -> Result<(), Box<dyn std::error::Error>> {
+        let parsed = parse_plugin_args(
+            &args(&[
+                "path=/runs/reeds",
+                "weather_year=2012",
+                "solve_year=2025",
+                "enabled=true",
+                "years=[2012,2025]",
+            ]),
+            &spec(),
+        )?;
+
+        assert_eq!(parsed["weather_year"], serde_json::json!(2012));
+        assert_eq!(parsed["enabled"], serde_json::json!(true));
+        assert_eq!(parsed["years"], serde_json::json!([2012, 2025]));
+        Ok(())
+    }
+
+    #[test]
+    fn reports_unknown_flag_with_suggestion() -> Result<(), Box<dyn std::error::Error>> {
+        let err = match parse_plugin_args(
+            &args(&[
+                "--path",
+                "/runs/reeds",
+                "--weathear_year",
+                "2012",
+                "--solve-year",
+                "2025",
+            ]),
+            &spec(),
+        ) {
+            Ok(_) => return Err("typo should be rejected".into()),
+            Err(err) => err,
+        };
+        let message = err.to_string();
+
+        assert!(message.contains("unknown option '--weathear_year'"));
+        assert!(message.contains("Did you mean '--weather-year'?"));
+        assert!(message.contains("Try:"));
+        Ok(())
+    }
+
+    #[test]
+    fn reports_missing_required_options() -> Result<(), Box<dyn std::error::Error>> {
+        let err = match parse_plugin_args(&args(&["--weather-year", "2012"]), &spec()) {
+            Ok(_) => return Err("missing required args should be rejected".into()),
+            Err(err) => err,
+        };
+        let message = err.to_string();
+
+        assert!(message.contains("missing required plugin option(s)"));
+        assert!(message.contains("--path"));
+        assert!(message.contains("--solve-year"));
+        Ok(())
+    }
 }

--- a/crates/r2x-cli/src/help.rs
+++ b/crates/r2x-cli/src/help.rs
@@ -2,6 +2,7 @@ use crate::manifest_lookup::resolve_plugin_ref;
 use colored::Colorize;
 use r2x_logger as logger;
 use r2x_manifest::types::Manifest;
+use std::collections::BTreeSet;
 
 /// Show help for the run command when invoked with no arguments
 pub fn show_run_help() -> Result<(), String> {
@@ -88,21 +89,54 @@ pub fn show_plugin_help(plugin_name: &str) -> Result<(), String> {
         println!();
     }
 
+    let required_options = required_plugin_options(plugin);
+    let usage_options = if required_options.is_empty() {
+        " [OPTIONS]".to_string()
+    } else {
+        format_option_usage(&required_options)
+    };
+    let example_options = if required_options.is_empty() {
+        plugin_option_names(plugin)
+            .iter()
+            .next()
+            .map(|name| format!(" --{} <value>", name))
+            .unwrap_or_default()
+    } else {
+        format_option_usage(&required_options)
+    };
+
+    println!("\nUsage:");
+    println!("  r2x run plugin {}{}", plugin_name, usage_options);
+    println!("    (add -q to silence logs, -q -q to hide stdout)");
+
     // Show parameters
     if !plugin.parameters.is_empty() {
-        println!("\nParameters:");
+        println!("\nPlugin options:");
         for param in &plugin.parameters {
             let module_str = param
                 .module
                 .as_ref()
                 .map(|m| format!(" ({})", m))
                 .unwrap_or_default();
+            let req_marker = if required_param_is_user_supplied(
+                plugin,
+                param.name.as_ref(),
+                param.required && param.default.is_none(),
+            ) {
+                " (required)"
+            } else {
+                ""
+            };
             println!(
-                "  --{:<20} {}{}",
-                param.name,
+                "  --{:<20} {}{}{}",
+                cli_flag_name(param.name.as_ref()),
                 param.format_types(),
-                module_str
+                module_str,
+                req_marker
             );
+            if param.name.contains('_') {
+                println!("      Alias: --{}", param.name);
+            }
             if let Some(ref desc) = param.description {
                 println!("      {}", desc);
             }
@@ -111,22 +145,112 @@ pub fn show_plugin_help(plugin_name: &str) -> Result<(), String> {
 
     // Show config schema
     if !plugin.config_schema.is_empty() {
-        println!("\nConfiguration Schema:");
+        println!("\nConfiguration options:");
         for (field_name, field) in plugin.config_schema.iter() {
-            let req_marker = if field.required { " (required)" } else { "" };
+            let req_marker = if field.required && field.default.is_none() {
+                " (required)"
+            } else {
+                ""
+            };
             println!(
                 "  --{:<20} {:?}{}",
-                field_name, field.field_type, req_marker
+                cli_flag_name(field_name.as_ref()),
+                field.field_type,
+                req_marker
             );
+            if field_name.contains('_') {
+                println!("      Alias: --{}", field_name);
+            }
         }
     }
 
-    println!("\nUsage:");
-    println!("  r2x run plugin {} [OPTIONS]", plugin_name);
-    println!("    (add -q to silence logs, -q -q to hide stdout)");
+    println!("\nCompatibility:");
+    println!("  key=value arguments are also supported:");
+    println!("    {}", compatibility_example(plugin));
+    println!("  --set key=value is accepted as an explicit key/value form.");
+
     println!("\nExamples:");
-    println!("  r2x run --plugin {} --show-help", plugin_name);
-    println!("  r2x run --plugin {} <args>", plugin_name);
+    println!("  r2x run plugin {} --show-help", plugin_name);
+    println!("  r2x run plugin {}{}", plugin_name, example_options);
 
     Ok(())
+}
+
+fn required_plugin_options(plugin: &r2x_manifest::types::Plugin) -> BTreeSet<String> {
+    let mut options = BTreeSet::new();
+
+    for param in &plugin.parameters {
+        if required_param_is_user_supplied(
+            plugin,
+            param.name.as_ref(),
+            param.required && param.default.is_none(),
+        ) {
+            options.insert(cli_flag_name(param.name.as_ref()));
+        }
+    }
+
+    for (field_name, field) in plugin.config_schema.iter() {
+        if field.required && field.default.is_none() {
+            options.insert(cli_flag_name(field_name.as_ref()));
+        }
+    }
+
+    options
+}
+
+fn plugin_option_names(plugin: &r2x_manifest::types::Plugin) -> BTreeSet<String> {
+    let mut options = BTreeSet::new();
+    for param in &plugin.parameters {
+        options.insert(cli_flag_name(param.name.as_ref()));
+    }
+    for (field_name, _) in plugin.config_schema.iter() {
+        options.insert(cli_flag_name(field_name.as_ref()));
+    }
+    options
+}
+
+fn compatibility_example(plugin: &r2x_manifest::types::Plugin) -> String {
+    let mut keys: BTreeSet<String> = BTreeSet::new();
+    for param in &plugin.parameters {
+        keys.insert(param.name.to_string());
+    }
+    for (field_name, _) in plugin.config_schema.iter() {
+        keys.insert(field_name.to_string());
+    }
+
+    if keys.is_empty() {
+        return "key=value".to_string();
+    }
+
+    keys.iter()
+        .map(|key| format!("{}=<value>", key))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn format_option_usage(options: &BTreeSet<String>) -> String {
+    options.iter().fold(String::new(), |mut usage, name| {
+        usage.push_str(" --");
+        usage.push_str(name);
+        usage.push_str(" <value>");
+        usage
+    })
+}
+
+fn required_param_is_user_supplied(
+    plugin: &r2x_manifest::types::Plugin,
+    param_name: &str,
+    has_no_default: bool,
+) -> bool {
+    if !has_no_default {
+        return false;
+    }
+    if param_name == "config" && plugin.config_class.is_some() && plugin.config_module.is_some() {
+        return false;
+    }
+    !matches!(param_name, "store" | "data_store")
+}
+
+fn cli_flag_name(key: &str) -> String {
+    key.replace('_', "-")
 }

--- a/crates/r2x-cli/tests/integration.rs
+++ b/crates/r2x-cli/tests/integration.rs
@@ -294,6 +294,113 @@ fn test_pipeline_reeds_test_runs() {
 }
 
 #[test]
+fn test_direct_plugin_accepts_flag_forms() {
+    let Ok(env) = PipelineHarness::new() else {
+        return;
+    };
+    let reeds_path = env
+        .home_path()
+        .join("data")
+        .join("reeds-store")
+        .to_string_lossy()
+        .to_string();
+    let path_key_value = format!("path={}", reeds_path);
+
+    env.command()
+        .args([
+            "run",
+            "plugin",
+            "r2x_reeds.parser",
+            "--path",
+            &reeds_path,
+            "--weather-year",
+            "2012",
+            "--solve-year=2025",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("reeds"));
+
+    env.command()
+        .args([
+            "run",
+            "plugin",
+            "r2x_reeds.parser",
+            &path_key_value,
+            "weather_year=2012",
+            "solve_year=2025",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("reeds"));
+
+    env.command()
+        .args([
+            "run",
+            "plugin",
+            "r2x_reeds.parser",
+            "--set",
+            &path_key_value,
+            "--weather_year",
+            "2012",
+            "--solve-year",
+            "2025",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("reeds"));
+}
+
+#[test]
+fn test_direct_plugin_unknown_option_suggests_known_flag() {
+    let Ok(env) = PipelineHarness::new() else {
+        return;
+    };
+    let reeds_path = env
+        .home_path()
+        .join("data")
+        .join("reeds-store")
+        .to_string_lossy()
+        .to_string();
+
+    env.command()
+        .args([
+            "run",
+            "plugin",
+            "r2x_reeds.parser",
+            "--path",
+            &reeds_path,
+            "--weathear_year",
+            "2012",
+            "--solve-year",
+            "2025",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("unknown option '--weathear_year'"))
+        .stderr(predicate::str::contains("Did you mean '--weather-year'?"));
+}
+
+#[test]
+fn test_direct_plugin_help_prefers_copy_pasteable_kebab_flags() {
+    let Ok(env) = PipelineHarness::new() else {
+        return;
+    };
+
+    env.command()
+        .args(["run", "plugin", "r2x_reeds.parser", "--show-help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "r2x run plugin r2x_reeds.parser --path <value> --solve-year <value> --weather-year <value>",
+        ))
+        .stdout(predicate::str::contains("--weather-year"))
+        .stdout(predicate::str::contains("Alias: --weather_year"))
+        .stdout(predicate::str::contains("Compatibility:"))
+        .stdout(predicate::str::contains("weather_year=<value>"));
+}
+
+#[test]
 fn test_pipeline_s2p_runs() {
     let Ok(env) = PipelineHarness::new() else {
         return;
@@ -399,6 +506,13 @@ fn test_run_plugin_benchmark_repeat_outputs_summary() {
         return;
     };
 
+    let reeds_path = env
+        .home_path()
+        .join("data")
+        .join("reeds-store")
+        .to_string_lossy()
+        .to_string();
+
     let assert = env
         .command()
         .args([
@@ -408,6 +522,10 @@ fn test_run_plugin_benchmark_repeat_outputs_summary() {
             "--repeat",
             "3",
             "--benchmark",
+            "--path",
+            &reeds_path,
+            "--weather-year",
+            "2012",
             "solve_year=2032",
         ])
         .assert()
@@ -667,6 +785,18 @@ module = "r2x_reeds.parser"
 class_name = "ReEDSParser"
 config_class = "ReEDSConfig"
 config_module = "r2x_reeds.parser"
+
+[packages.plugins.config_schema.path]
+type = "str"
+required = true
+
+[packages.plugins.config_schema.solve_year]
+type = "int"
+required = true
+
+[packages.plugins.config_schema.weather_year]
+type = "int"
+required = true
 
 [[packages.plugins]]
 name = "r2x_reeds.no_stdin_function"


### PR DESCRIPTION
Closes #145

## Summary

- Accept direct plugin options as kebab/snake flags, `--flag=value`, existing `key=value`, and `--set key=value`, normalizing to snake_case config keys.
- Add schema-aware unknown-option and missing-required diagnostics with close-match suggestions and retry examples.
- Make `r2x run plugin <name> --show-help` prefer copy-pasteable kebab-case examples while documenting aliases and key/value compatibility.
- Route direct class plugins through the same runtime binding target format used by pipelines so direct class invocation works with plugin metadata.

## Acceptance criteria

- [x] `r2x run plugin <plugin> --weather-year 2012 --solve-year 2025 --path <dir>` produces the same plugin config as `weather_year=2012 solve_year=2025 path=<dir>`.
  - Evidence: `commands::run::plugin::tests::parses_plugin_flags_and_key_value_forms_to_same_config` asserts identical normalized JSON; `test_direct_plugin_accepts_flag_forms` runs the direct plugin with flag and key/value forms.
- [x] `--weather-year` and `--weather_year` are both accepted as aliases for the same canonical config key.
  - Evidence: unit coverage and integration coverage include both flag styles.
- [x] `--weather-year=2012` is accepted.
  - Evidence: unit coverage includes equals-form flags; integration uses `--solve-year=2025` for the same parser path.
- [x] Existing `key=value` plugin invocations continue to work.
  - Evidence: unit and integration tests cover `path=... weather_year=... solve_year=...`.
- [x] `--set key=value` is accepted as an explicit compatibility form.
  - Evidence: unit and integration tests cover `--set path=...` and repeated `--set` forms.
- [x] JSON-ish value parsing behavior for numbers, booleans, arrays, objects, and strings is preserved.
  - Evidence: `commands::run::plugin::tests::preserves_jsonish_value_parsing` covers integers, booleans, and arrays; parser still falls back through the existing serde/number/string path.
- [x] Unknown plugin options return an actionable error.
  - Evidence: unit and integration tests assert `unknown option '--weathear_year'` plus retry guidance.
- [x] Unknown plugin options suggest close known plugin option names when possible.
  - Evidence: unit and integration tests assert `Did you mean '--weather-year'?`.
- [x] Plugin help examples use syntax accepted by `r2x run plugin`.
  - Evidence: integration test asserts `r2x run plugin r2x_reeds.parser --path <value> --solve-year <value> --weather-year <value>`.
- [x] Help prefers kebab-case flags while documenting `key=value` compatibility.
  - Evidence: integration test asserts `--weather-year`, `Alias: --weather_year`, `Compatibility:`, and `weather_year=<value>`.
- [x] Tests cover flag parsing, `key=value` compatibility, typo diagnostics, and help text for at least one plugin with snake_case fields.
  - Evidence: new parser unit tests and integration tests use the ReEDS parser fixture with `weather_year` and `solve_year` schema fields.

## Deviations from the original plan

- Positional path shorthand remains out of scope for this PR, matching the work packet non-goal.
- No machine-readable plugin discovery or dry-run JSON surfaces were added.

## Testing Strategy

- `cargo fmt --all`
- `cargo test -p r2x plugin::tests`
- `cargo test -p r2x --test integration`
- `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- `cargo test --all --all-features`

## References

- #145
