### PR TITLE
fix(read): resolve time-series sidecars from JSON file

### DIFF
--- a/crates/r2x-cli/src/commands/read.rs
+++ b/crates/r2x-cli/src/commands/read.rs
@@ -100,6 +100,7 @@ pub fn handle_read(cmd: ReadCommand, opts: GlobalOpts) -> Result<(), Box<dyn std
         .replace('\\', "\\\\");
 
     let display_source_str = display_source.replace('\\', "\\\\").replace('\'', "\\'");
+    let source_is_stdin = if is_stdin { "True" } else { "False" };
 
     let python_code = format!(
         r#"
@@ -764,8 +765,12 @@ class R2XMagics:
 
         # Create new System object
         try:
-            cwd = os.getcwd()
-            new_system = System.from_dict(data, cwd)
+            time_series_parent_dir = Path(file_path).resolve().parent
+            missing_sidecar = missing_time_series_sidecar(data, time_series_parent_dir)
+            if missing_sidecar is not None:
+                print(format_time_series_sidecar_error(*missing_sidecar))
+                return
+            new_system = System.from_dict(data, time_series_parent_dir)
         except Exception as e:
             print(format_system_error(e))
             return
@@ -1132,6 +1137,7 @@ def print_startup_banner(display_source, plugins):
 
 DISPLAY_SOURCE = r'''{}'''
 JSON_PATH = r'''{}'''
+SOURCE_IS_STDIN = {}
 
 
 def format_json_error(json_path, error):
@@ -1175,6 +1181,54 @@ def format_json_error(json_path, error):
     msg_lines.append("  - Check for trailing commas in arrays/objects")
     msg_lines.append("  - Ensure all strings are properly quoted")
     msg_lines.append("  - Verify brackets/braces are balanced")
+    msg_lines.append("")
+    return "\n".join(msg_lines)
+
+
+def time_series_parent_dir_for(json_path, source_is_stdin):
+    """Return the base directory used for relative time-series sidecars."""
+    if source_is_stdin:
+        return Path(os.getcwd())
+    return Path(json_path).resolve().parent
+
+
+def missing_time_series_sidecar(data, time_series_parent_dir):
+    """Return a missing sidecar descriptor, if serialized metadata needs one."""
+    if not isinstance(data, dict):
+        return None
+
+    time_series = data.get("time_series")
+    if not isinstance(time_series, dict):
+        return None
+
+    directory = time_series.get("directory")
+    if not directory:
+        return None
+
+    sidecar_dir = Path(directory)
+    if not sidecar_dir.is_absolute():
+        sidecar_dir = time_series_parent_dir / sidecar_dir
+
+    if not sidecar_dir.exists():
+        return ("directory", sidecar_dir)
+
+    db_filename = getattr(System, "DB_FILENAME", "time_series_metadata.db")
+    metadata_db = sidecar_dir / db_filename
+    if not metadata_db.exists():
+        return ("metadata database", metadata_db)
+
+    return None
+
+
+def format_time_series_sidecar_error(kind, path):
+    """Format missing time-series sidecar errors without schema guidance."""
+    msg_lines = []
+    msg_lines.append("\n  Time-series Sidecar Error")
+    msg_lines.append("  " + "-" * 50)
+    msg_lines.append(f"  Missing time-series sidecar {{kind}}: {{path}}")
+    msg_lines.append("")
+    msg_lines.append("  This JSON references external time-series sidecar data that is required to load the system.")
+    msg_lines.append("  Keep the JSON file together with its generated time-series sidecar directory, or re-export the system.")
     msg_lines.append("")
     return "\n".join(msg_lines)
 
@@ -1225,9 +1279,13 @@ try:
         except json.JSONDecodeError as e:
             print(format_json_error(JSON_PATH, e), file=py_sys.stderr)
             py_sys.exit(1)
-    cwd = os.getcwd()
+    time_series_parent_dir = time_series_parent_dir_for(JSON_PATH, SOURCE_IS_STDIN)
+    missing_sidecar = missing_time_series_sidecar(data, time_series_parent_dir)
+    if missing_sidecar is not None:
+        print(format_time_series_sidecar_error(*missing_sidecar), file=py_sys.stderr)
+        py_sys.exit(1)
     try:
-        system = System.from_dict(data, cwd)
+        system = System.from_dict(data, time_series_parent_dir)
     except Exception as e:
         print(format_system_error(e), file=py_sys.stderr)
         py_sys.exit(1)
@@ -1347,7 +1405,7 @@ shell(
     global_ns=context,
 )
 "#,
-        display_source_str, file_path_str
+        display_source_str, file_path_str, source_is_stdin
     );
 
     logger::debug("Generated Python initialization code");

--- a/crates/r2x-cli/tests/integration.rs
+++ b/crates/r2x-cli/tests/integration.rs
@@ -547,6 +547,151 @@ fn test_run_plugin_benchmark_repeat_outputs_summary() {
     }
 }
 
+#[test]
+fn test_read_file_resolves_time_series_sidecar_relative_to_json_parent() {
+    let Ok(env) = PipelineHarness::new() else {
+        return;
+    };
+
+    let system_dir = env.home_path().join("exports").join("system");
+    let cwd = env.home_path().join("caller-cwd");
+    let sidecar_dir = system_dir.join("system_time_series");
+    if fs::create_dir_all(&sidecar_dir).is_err() || fs::create_dir_all(&cwd).is_err() {
+        return;
+    }
+    if fs::write(sidecar_dir.join("time_series_metadata.db"), "stub").is_err() {
+        return;
+    }
+    let system_path = system_dir.join("system.json");
+    if fs::write(&system_path, system_json("system_time_series")).is_err() {
+        return;
+    }
+
+    env.command()
+        .current_dir(cwd)
+        .env("R2X_READ_NONINTERACTIVE", "1")
+        .args([
+            "read",
+            system_path.to_string_lossy().as_ref(),
+            "--no-banner",
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_read_stdin_keeps_relative_time_series_sidecars_resolved_from_cwd() {
+    let Ok(env) = PipelineHarness::new() else {
+        return;
+    };
+
+    let cwd = env.home_path().join("stdin-cwd");
+    let sidecar_dir = cwd.join("stdin_time_series");
+    if fs::create_dir_all(&sidecar_dir).is_err() {
+        return;
+    }
+    if fs::write(sidecar_dir.join("time_series_metadata.db"), "stub").is_err() {
+        return;
+    }
+
+    env.command()
+        .current_dir(cwd)
+        .env("R2X_READ_NONINTERACTIVE", "1")
+        .write_stdin(system_json("stdin_time_series"))
+        .args(["read", "--no-banner"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_read_missing_time_series_sidecar_directory_reports_required_path() {
+    let Ok(env) = PipelineHarness::new() else {
+        return;
+    };
+
+    let system_dir = env.home_path().join("exports").join("missing-sidecar");
+    if fs::create_dir_all(&system_dir).is_err() {
+        return;
+    }
+    let missing_sidecar = env.home_path().join("cache-backed-missing-time-series");
+    let system_path = system_dir.join("system.json");
+    if fs::write(&system_path, system_json(missing_sidecar.to_string_lossy())).is_err() {
+        return;
+    }
+    let missing_sidecar_text = missing_sidecar.to_string_lossy().to_string();
+
+    env.command()
+        .env("R2X_READ_NONINTERACTIVE", "1")
+        .args([
+            "read",
+            system_path.to_string_lossy().as_ref(),
+            "--no-banner",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Time-series Sidecar Error"))
+        .stderr(predicate::str::contains(
+            "Missing time-series sidecar directory",
+        ))
+        .stderr(predicate::str::contains(missing_sidecar_text))
+        .stderr(predicate::str::contains(
+            "JSON references external time-series sidecar data",
+        ))
+        .stderr(predicate::str::contains("Verify the JSON structure").not());
+}
+
+#[test]
+fn test_read_missing_time_series_metadata_db_reports_required_path() {
+    let Ok(env) = PipelineHarness::new() else {
+        return;
+    };
+
+    let system_dir = env.home_path().join("exports").join("missing-metadata-db");
+    let sidecar_dir = system_dir.join("system_time_series");
+    if fs::create_dir_all(&sidecar_dir).is_err() {
+        return;
+    }
+    let system_path = system_dir.join("system.json");
+    if fs::write(&system_path, system_json("system_time_series")).is_err() {
+        return;
+    }
+    let metadata_db = sidecar_dir.join("time_series_metadata.db");
+    let metadata_db_text = metadata_db.to_string_lossy().to_string();
+
+    env.command()
+        .env("R2X_READ_NONINTERACTIVE", "1")
+        .args([
+            "read",
+            system_path.to_string_lossy().as_ref(),
+            "--no-banner",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Time-series Sidecar Error"))
+        .stderr(predicate::str::contains(
+            "Missing time-series sidecar metadata database",
+        ))
+        .stderr(predicate::str::contains(metadata_db_text))
+        .stderr(predicate::str::contains(
+            "JSON references external time-series sidecar data",
+        ))
+        .stderr(predicate::str::contains("Verify the JSON structure").not());
+}
+
+fn system_json(sidecar_directory: impl AsRef<str>) -> String {
+    serde_json::json!({
+        "components": [],
+        "supplemental_attributes": [],
+        "time_series": {
+            "directory": sidecar_directory.as_ref(),
+            "time_series_storage_type": "arrow"
+        },
+        "uuid": "00000000-0000-0000-0000-000000000001",
+        "r2x_core_version": "test"
+    })
+    .to_string()
+}
+
 struct PipelineHarness {
     _home: TempDir,
     config_path: PathBuf,
@@ -584,6 +729,8 @@ impl PipelineHarness {
         let manifest_path = cache_dir.join("manifest.toml");
         fs::write(&manifest_path, stub_manifest_toml())?;
 
+        copy_python_stub("IPython", &site_packages)?;
+        copy_python_stub("traitlets", &site_packages)?;
         copy_python_stub("r2x_reeds", &site_packages)?;
         copy_python_stub("r2x_sienna", &site_packages)?;
         copy_python_stub("r2x_core", &site_packages)?;

--- a/crates/r2x-cli/tests/python_plugins/IPython/__init__.py
+++ b/crates/r2x-cli/tests/python_plugins/IPython/__init__.py
@@ -1,0 +1,1 @@
+"""Minimal IPython stub for r2x read integration tests."""

--- a/crates/r2x-cli/tests/python_plugins/IPython/terminal/__init__.py
+++ b/crates/r2x-cli/tests/python_plugins/IPython/terminal/__init__.py
@@ -1,0 +1,1 @@
+"""Minimal IPython.terminal stub for integration tests."""

--- a/crates/r2x-cli/tests/python_plugins/IPython/terminal/embed.py
+++ b/crates/r2x-cli/tests/python_plugins/IPython/terminal/embed.py
@@ -1,0 +1,14 @@
+"""Minimal InteractiveShellEmbed stub for noninteractive read tests."""
+
+
+class InteractiveShellEmbed:
+    def __init__(self, *args, **kwargs):
+        self.execution_count = 1
+        self.user_ns = {}
+        self.prompts = None
+
+    def register_magic_function(self, *args, **kwargs):
+        return None
+
+    def __call__(self, *args, **kwargs):
+        return None

--- a/crates/r2x-cli/tests/python_plugins/IPython/terminal/prompts.py
+++ b/crates/r2x-cli/tests/python_plugins/IPython/terminal/prompts.py
@@ -1,0 +1,13 @@
+"""Minimal prompt types for noninteractive read tests."""
+
+
+class Prompts:
+    def __init__(self, shell):
+        self.shell = shell
+
+
+class Token:
+    Prompt = "Prompt"
+    PromptNum = "PromptNum"
+    OutPrompt = "OutPrompt"
+    OutPromptNum = "OutPromptNum"

--- a/crates/r2x-cli/tests/python_plugins/r2x_core/system.py
+++ b/crates/r2x-cli/tests/python_plugins/r2x_core/system.py
@@ -3,14 +3,28 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 
 class System:
-    """Stub System class with from_json API expected by runtime bridge."""
+    """Stub System class with JSON APIs expected by runtime bridges."""
+
+    DB_FILENAME = "time_series_metadata.db"
 
     def __init__(self, data: dict[str, Any]) -> None:
         self.data = data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any], time_series_parent_dir: str | Path) -> "System":
+        time_series = data.get("time_series")
+        if isinstance(time_series, dict) and time_series.get("directory"):
+            sidecar_dir = Path(time_series["directory"])
+            if not sidecar_dir.is_absolute():
+                sidecar_dir = Path(time_series_parent_dir) / sidecar_dir
+            if not sidecar_dir.exists() or not (sidecar_dir / cls.DB_FILENAME).exists():
+                raise OSError("unable to open database file")
+        return cls(data)
 
     @classmethod
     def from_json(cls, payload: bytes | str) -> "System":

--- a/crates/r2x-cli/tests/python_plugins/traitlets/__init__.py
+++ b/crates/r2x-cli/tests/python_plugins/traitlets/__init__.py
@@ -1,0 +1,1 @@
+"""Minimal traitlets stub for integration tests."""

--- a/crates/r2x-cli/tests/python_plugins/traitlets/config.py
+++ b/crates/r2x-cli/tests/python_plugins/traitlets/config.py
@@ -1,0 +1,11 @@
+"""Minimal traitlets.config stub for noninteractive read tests."""
+
+
+class _Section:
+    pass
+
+
+class Config:
+    def __init__(self):
+        self.TerminalInteractiveShell = _Section()
+        self.HistoryManager = _Section()


### PR DESCRIPTION
Closes #144

Draft PR — not ready to merge until validation and review are complete.

## Summary

- Resolves file-based `r2x read` time-series sidecars relative to the JSON file parent, matching `System.from_json` semantics.
- Preserves piped/stdin JSON behavior by keeping relative stdin sidecars resolved from the caller's current working directory.
- Adds explicit missing time-series sidecar diagnostics before generic schema guidance.
- Adds focused integration coverage for file-relative sidecars, stdin sidecars, missing sidecar directories, and missing metadata DB files.

## Acceptance criteria

- [x] `r2x read path/to/system.json` loads a system exported with `System.to_json("path/to/system.json")` when run from a different current working directory.
  - Evidence: `test_read_file_resolves_time_series_sidecar_relative_to_json_parent` passes.
- [x] `r2x read system.json` preserves stdin support without regressing piped JSON behavior.
  - Evidence: `test_read_stdin_keeps_relative_time_series_sidecars_resolved_from_cwd` passes.
- [x] When the time-series sidecar directory or SQLite metadata DB is missing, the error message names the missing path and explains that the JSON sidecar data is required.
  - Evidence: `test_read_missing_time_series_sidecar_directory_reports_required_path` and `test_read_missing_time_series_metadata_db_reports_required_path` pass.
- [x] The generic "verify schema" guidance is not shown as the primary explanation for missing sidecar database failures.
  - Evidence: missing-sidecar tests assert stderr does not contain `Verify the JSON structure`.
- [x] A regression test covers file-based JSON loading with sidecar time-series data outside the process cwd.
  - Evidence: `test_read_file_resolves_time_series_sidecar_relative_to_json_parent` changes cwd before invoking `r2x read`.
- [x] A regression test or documented behavior covers saved stdout/plugin JSON that references cache-backed time-series paths.
  - Evidence: `test_read_missing_time_series_sidecar_directory_reports_required_path` covers an absolute cache-backed sidecar path that is absent and verifies the specific diagnostic.

## Deviations from the original plan

- Used the existing integration-test Python stubs instead of creating a real `r2x_core.System.to_json(...)` fixture, keeping the test focused on CLI path-resolution and error-reporting behavior without adding external package/network dependencies.
- Added lightweight IPython/traitlets stubs so `r2x read` noninteractive integration tests can exercise the real CLI path without installing test-only Python dependencies.

## Testing Strategy

```bash
cargo fmt --all
cargo test -p r2x test_read -- --nocapture
cargo clippy --all --benches --tests --examples --all-features -- -D warnings
```

## References

- https://github.com/NatLabRockies/r2x-cli/issues/144
