### PR TITLE
fix(cli): preserve UTF-8 JSON when writing plugin output on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ r2x run pipeline.yaml my-pipeline -o output.json
 
 ### Running Plugins Directly
 
-Skip the pipeline and run a single plugin with inline arguments:
+Skip the pipeline and run a single plugin with inline arguments.
+
+Use `--output <FILE>` when you want a portable JSON artifact, especially on Windows. Shell redirection in PowerShell can produce UTF-16 files, while `r2x run plugin ... --output <FILE>` writes the JSON bytes directly.
 
 ```bash
 # Run a plugin directly with idiomatic flags
@@ -162,6 +164,13 @@ r2x run plugin r2x-reeds.reeds-parser \
 
 # Show a plugin's help
 r2x run plugin r2x-reeds.reeds-parser --show-help
+
+# Write portable UTF-8 JSON directly to a file
+r2x run plugin r2x-reeds.reeds-parser \
+  --output plugin-output.json \
+  --path /path/to/reeds/run \
+  --solve-year 2030 \
+  --weather-year 2012
 
 # Run repeated invocations and print timing summary
 r2x run plugin r2x-reeds.reeds-parser --repeat 10 --benchmark solve_year=2030

--- a/crates/r2x-cli/src/commands/run/mod.rs
+++ b/crates/r2x-cli/src/commands/run/mod.rs
@@ -95,6 +95,12 @@ pub struct PluginCommand {
     pub show_help: bool,
     #[arg(
         long,
+        value_name = "FILE",
+        help = "Write plugin JSON output to a UTF-8 file instead of stdout"
+    )]
+    pub output: Option<String>,
+    #[arg(
+        long,
         value_name = "N",
         default_value = "1",
         help = "Repeat plugin invocation N times"

--- a/crates/r2x-cli/src/commands/run/plugin.rs
+++ b/crates/r2x-cli/src/commands/run/plugin.rs
@@ -24,6 +24,7 @@ pub(super) fn handle_plugin_command(cmd: PluginCommand, opts: &GlobalOpts) -> Re
                     &plugin_name,
                     &cmd.args,
                     opts,
+                    cmd.output,
                     cmd.repeat.get(),
                     cmd.benchmark,
                 )?;
@@ -52,6 +53,7 @@ fn run_plugin(
     plugin_name: &str,
     args: &[String],
     opts: &GlobalOpts,
+    output_file: Option<String>,
     repeat: usize,
     benchmark: bool,
 ) -> Result<(), RunError> {
@@ -129,7 +131,14 @@ fn run_plugin(
     );
 
     let no_stdout = opts.no_stdout || logger::get_no_stdout();
-    if !result.is_empty() && result != "null" {
+    if let Some(output_path) = output_file {
+        if !result.is_empty() {
+            logger::step(&format!("Writing plugin output to: {}", output_path));
+            std::fs::write(&output_path, result.as_bytes())
+                .map_err(|e| RunError::Pipeline(crate::errors::PipelineError::Io(e)))?;
+            logger::success(&format!("Plugin output saved to: {}", output_path));
+        }
+    } else if !result.is_empty() && result != "null" {
         if opts.suppress_stdout() || no_stdout {
             logger::debug("Plugin output suppressed");
         } else {

--- a/crates/r2x-cli/src/help.rs
+++ b/crates/r2x-cli/src/help.rs
@@ -40,7 +40,7 @@ pub fn show_run_help() -> Result<(), String> {
     println!();
     println!("  Run a plugin directly:");
     println!("    r2x run plugin <plugin-name> [OPTIONS]");
-    println!("      (use -q for quiet logs, -q -q to suppress plugin stdout)");
+    println!("      (use --output <FILE> for portable UTF-8 JSON files; use -q for quiet logs, -q -q to suppress plugin stdout)");
     println!();
     println!("  Get plugin help:");
     println!("    r2x run plugin <plugin-name> --show-help");
@@ -107,7 +107,7 @@ pub fn show_plugin_help(plugin_name: &str) -> Result<(), String> {
 
     println!("\nUsage:");
     println!("  r2x run plugin {}{}", plugin_name, usage_options);
-    println!("    (add -q to silence logs, -q -q to hide stdout)");
+    println!("    (add --output <FILE> for UTF-8 JSON files, or -q to silence logs, -q -q to hide stdout)");
 
     // Show parameters
     if !plugin.parameters.is_empty() {

--- a/crates/r2x-cli/tests/integration.rs
+++ b/crates/r2x-cli/tests/integration.rs
@@ -123,8 +123,50 @@ fn test_plugins_help() {
             "Usage: {} run plugin",
             EXECUTABLE_NAME
         )))
+        .stdout(predicate::str::contains("--output <FILE>"))
         .stdout(predicate::str::contains("--repeat"))
         .stdout(predicate::str::contains("--benchmark"));
+}
+
+#[test]
+fn test_direct_plugin_output_writes_utf8_json_and_read_accepts_it(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Ok(env) = PipelineHarness::new() else {
+        return Ok(());
+    };
+
+    let output_path = env.home_path().join("plugin-output.json");
+    env.command()
+        .args([
+            "run",
+            "plugin",
+            "r2x-sienna.parser",
+            "--output",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .assert()
+        .success();
+
+    let bytes = fs::read(&output_path)?;
+    assert!(bytes.starts_with(b"{"));
+    let expected = "sienña".as_bytes();
+    assert!(bytes
+        .windows(expected.len())
+        .any(|window| window == expected));
+    assert!(!bytes.starts_with(&[0xFF, 0xFE]));
+    assert!(!bytes.starts_with(&[0xFE, 0xFF]));
+
+    env.command()
+        .env("R2X_READ_NONINTERACTIVE", "1")
+        .args([
+            "read",
+            output_path.to_string_lossy().as_ref(),
+            "--no-banner",
+        ])
+        .assert()
+        .success();
+
+    Ok(())
 }
 
 #[test]

--- a/crates/r2x-cli/tests/python_plugins/r2x_core/system.py
+++ b/crates/r2x-cli/tests/python_plugins/r2x_core/system.py
@@ -26,6 +26,9 @@ class System:
                 raise OSError("unable to open database file")
         return cls(data)
 
+    def to_json(self) -> bytes:
+        return json.dumps(self.data, ensure_ascii=False).encode("utf-8")
+
     @classmethod
     def from_json(cls, payload: bytes | str) -> "System":
         if isinstance(payload, bytes):

--- a/crates/r2x-cli/tests/python_plugins/r2x_sienna/parser.py
+++ b/crates/r2x-cli/tests/python_plugins/r2x_sienna/parser.py
@@ -31,4 +31,6 @@ class SiennaParser:
         return cls(config=ctx.config)
 
     def build_system(self) -> str:
-        return '{"system": "sienna", "status": "ok"}'
+        from r2x_core.system import System
+
+        return System({"system": "sienña", "status": "ok"})


### PR DESCRIPTION
Closes #155

## Summary
Add an explicit `--output <FILE>` path for `r2x run plugin` so plugin JSON can be written as UTF-8 bytes directly, avoiding Windows PowerShell redirection encoding issues. Existing stdout behavior remains unchanged when no output file is provided.

## Acceptance criteria
- [x] Plugin mode has an explicit output-file path for JSON results, or reuses an existing CLI output contract, that writes `result.as_bytes()` directly instead of relying on shell redirection.
  - Evidence: `crates/r2x-cli/src/commands/run/mod.rs`, `crates/r2x-cli/src/commands/run/plugin.rs`
- [x] The output file produced by plugin mode is UTF-8 JSON with no UTF-16 BOM and can be parsed by UTF-8 JSON readers.
  - Evidence: `crates/r2x-cli/tests/integration.rs` asserts raw bytes, UTF-8 non-ASCII content, and no BOM; plugin fixture returns a `System` with `to_json()` bytes encoded as UTF-8.
- [x] `r2x read <plugin-output-file>` can read a plugin output file produced by the new path without users changing the file encoding to UTF-16.
  - Evidence: `crates/r2x-cli/tests/integration.rs::test_direct_plugin_output_writes_utf8_json_and_read_accepts_it`
- [x] Existing stdout behavior for `r2x run plugin <name>` remains backward compatible when no output path is provided.
  - Evidence: stdout path is unchanged in `crates/r2x-cli/src/commands/run/plugin.rs`
- [x] Help text or user-facing docs mention the Windows-safe output-file path and avoid recommending PowerShell `>` redirection for JSON artifacts.
  - Evidence: `crates/r2x-cli/src/help.rs`, `README.md`
- [x] A regression test covers the plugin output-file bytes, including at least one non-ASCII JSON value or another byte-level assertion that would catch UTF-16/BOM output.
  - Evidence: `crates/r2x-cli/tests/integration.rs::test_direct_plugin_output_writes_utf8_json_and_read_accepts_it`

## Deviations from the original plan
- Added a dedicated plugin `--output` path instead of changing shell redirection behavior or infrasys serialization.
- The test plugin fixture was adjusted so the regression can assert raw UTF-8 bytes, not escaped ASCII-only JSON.

## Testing Strategy
- `cargo fmt --all`
- `cargo test -p r2x test_direct_plugin_output_writes_utf8_json_and_read_accepts_it -- --exact`
- `cargo test -p r2x test_plugins_help -- --exact`
- `cargo test -p r2x`
- `cargo clippy --all --benches --tests --examples --all-features`

## References
- Issue: https://github.com/NatLabRockies/r2x-cli/issues/155
- Draft PR: https://github.com/NatLabRockies/r2x-cli/pull/156
- Branch: fix/155-preserve-utf-8-json
