### PR TITLE
fix: recreate venv and refresh plugin metadata

### DIFF
--- a/crates/r2x-cli/src/commands/config.rs
+++ b/crates/r2x-cli/src/commands/config.rs
@@ -414,6 +414,7 @@ fn handle_python_install(version: Option<String>, _opts: GlobalOpts) {
                 return;
             }
 
+            config.migrate_legacy_venv();
             let venv_path = config.get_venv_path();
             logger::step(&format!(
                 "Installing Python {} and creating venv...",
@@ -475,15 +476,18 @@ fn handle_venv_create(skip_confirmation: bool) {
     ));
     match Config::load() {
         Ok(config) => {
+            config.migrate_legacy_venv();
             let venv_path = config.get_venv_path();
             let venv_dir = PathBuf::from(&venv_path);
 
-            if venv_dir.exists() {
-                let should_skip = skip_confirmation || std::env::var("R2X_VENV_YES").is_ok();
+            let should_skip = skip_confirmation || std::env::var("R2X_VENV_YES").is_ok();
+            let mut prompted_for_replacement = false;
 
+            if venv_dir.exists() {
                 if should_skip {
                     logger::debug("Skipping confirmation (--yes flag or R2X_VENV_YES set)");
                 } else {
+                    prompted_for_replacement = true;
                     print!(
                         "{} A virtual environment already exists at `{}`. Do you want to replace it? {} ",
                         "?".bold().cyan(),
@@ -525,7 +529,7 @@ fn handle_venv_create(skip_confirmation: bool) {
                 Err(e) => logger::error(&format!("Failed to configure venv: {}", e)),
             }
 
-            if !skip_confirmation && std::env::var("R2X_VENV_YES").is_err() {
+            if prompted_for_replacement && !should_skip {
                 println!(
                     "\n{} Use the `{}` flag or set `{}` to skip this prompt",
                     "hint:".dimmed(),

--- a/crates/r2x-cli/src/commands/plugins/context.rs
+++ b/crates/r2x-cli/src/commands/plugins/context.rs
@@ -40,8 +40,7 @@ impl PluginContext {
         let site_packages = resolve_site_package_path(&PathBuf::from(&venv_path))
             .map_err(|e| PluginError::Python(format!("Failed to resolve site-packages: {e}")))?;
 
-        let uv_cache_dir = resolve_uv_cache_dir();
-        let locator = PackageLocator::new(site_packages, uv_cache_dir).map_err(|e| {
+        let locator = PackageLocator::new(site_packages).map_err(|e| {
             PluginError::Locator(format!("Failed to initialize package locator: {e}"))
         })?;
 
@@ -64,10 +63,4 @@ impl PluginContext {
     }
 }
 
-fn resolve_uv_cache_dir() -> Option<PathBuf> {
-    let base = std::env::var_os("UV_CACHE_DIR")
-        .map(PathBuf::from)
-        .or_else(|| dirs::cache_dir().map(|cache| cache.join("uv")));
-    base.map(|root| root.join("archive-v0"))
-        .filter(|path| path.exists())
-}
+

--- a/crates/r2x-cli/src/commands/plugins/context.rs
+++ b/crates/r2x-cli/src/commands/plugins/context.rs
@@ -62,5 +62,3 @@ impl PluginContext {
             .map_err(|e| PluginError::Locator(format!("Failed to refresh package locator: {e}")))
     }
 }
-
-

--- a/crates/r2x-cli/src/commands/plugins/install.rs
+++ b/crates/r2x-cli/src/commands/plugins/install.rs
@@ -52,81 +52,78 @@ pub fn install_plugin(
         )?;
         ctx.refresh_locator()?;
 
-        // Now discover all packages with entry points (like sync command)
+        // Now discover all packages with entry points (like sync command).
+        // The install transaction just mutated site-packages, so rebuild plugin
+        // metadata from disk instead of trusting any existing manifest entries.
         logger::info("Discovering plugins from installed packages...");
-        return discover_all_installed_packages(ctx, no_cache, total_start);
+        return discover_all_installed_packages(ctx, true, total_start);
     }
 
     let package_name_for_query = extract_package_name(package)?;
 
+    let can_reuse_installed_package = !editable
+        && !crate::plugins::package_spec::is_git_url(&package_spec)
+        && !crate::plugins::package_spec::is_local_path(&package_spec);
     let check_start = std::time::Instant::now();
-    let is_already_installed = if no_cache {
+    let installed_info = if no_cache || !can_reuse_installed_package {
         None
     } else {
-        match get_package_info(&ctx.uv_path, &ctx.python_path, &package_name_for_query) {
-            Ok((version, _deps)) => {
-                let has_plugins = ctx.manifest.packages.iter().any(|pkg| {
-                    pkg.name.as_ref() == package_name_for_query && !pkg.plugins.is_empty()
-                });
-
-                if has_plugins {
-                    logger::debug(&format!(
-                        "Package '{}' already installed and registered (check took {:?})",
-                        package_name_for_query,
-                        check_start.elapsed()
-                    ));
-                    Some(version)
-                } else {
-                    None
-                }
-            }
-            Err(_) => None,
-        }
+        get_package_info(&ctx.uv_path, &ctx.python_path, &package_name_for_query).ok()
     };
+    let is_already_installed = installed_info.as_ref().is_some_and(|(version, _deps)| {
+        ctx.manifest
+            .get_package(&package_name_for_query)
+            .is_some_and(|pkg| {
+                let version_matches = version
+                    .as_deref()
+                    .is_some_and(|installed_version| pkg.version.as_ref() == installed_version);
+                !pkg.plugins.is_empty() && version_matches
+            })
+    });
 
-    if is_already_installed.is_some() {
-        let elapsed_ms = total_start.elapsed().as_millis();
-        println!(
-            "{}",
-            format!("Audited 1 package in {}ms", elapsed_ms)
-                .bold()
-                .dimmed()
-        );
-        return Ok(());
+    if is_already_installed {
+        logger::debug(&format!(
+            "Package '{}' already installed and registered (check took {:?}); refreshing plugin metadata",
+            package_name_for_query,
+            check_start.elapsed()
+        ));
+    } else {
+        // Print status without spinner since we need interactive terminal for SSH prompts
+        logger::info(&format!("Installing: {}", package));
+        let start = std::time::Instant::now();
+        match run_pip_install(
+            &ctx.uv_path,
+            &ctx.python_path,
+            &package_spec,
+            editable,
+            no_cache,
+        ) {
+            Ok(()) => {
+                logger::debug(&format!("pip install took: {:?}", start.elapsed()));
+            }
+            Err(e) => {
+                logger::error(&format!("Failed to install: {}", package));
+                return Err(e);
+            }
+        }
+
+        // uv pip install mutates site-packages and dist-info directories. Refresh the
+        // locator cache so entry_points.txt discovery can see newly installed packages.
+        ctx.refresh_locator()?;
     }
 
-    // Print status without spinner since we need interactive terminal for SSH prompts
-    logger::info(&format!("Installing: {}", package));
     let start = std::time::Instant::now();
-    match run_pip_install(
-        &ctx.uv_path,
-        &ctx.python_path,
-        &package_spec,
-        editable,
-        no_cache,
-    ) {
-        Ok(()) => {
-            logger::debug(&format!("pip install took: {:?}", start.elapsed()));
-        }
-        Err(e) => {
-            logger::error(&format!("Failed to install: {}", package));
-            return Err(e);
-        }
-    }
-
-    // uv pip install mutates site-packages and dist-info directories. Refresh the
-    // locator cache so entry_points.txt discovery can see newly installed packages.
-    ctx.refresh_locator()?;
-
-    let start = std::time::Instant::now();
-    let (package_version, dependencies) =
+    let (package_version, dependencies) = if is_already_installed {
+        installed_info.unwrap_or((None, Vec::new()))
+    } else {
         match get_package_info(&ctx.uv_path, &ctx.python_path, &package_name_for_query) {
             Ok((version, deps)) => (version, deps),
             Err(e) => {
                 logger::debug(&format!("Failed to get package info: {}", e));
                 (None, Vec::new())
             }
-        };
+        }
+    };
     logger::debug(&format!("get_package_info took: {:?}", start.elapsed()));
 
     // source_path: local filesystem path for AST discovery (editable installs only)
@@ -155,7 +152,7 @@ pub fn install_plugin(
             package_name_full: package_name_for_query.clone(),
             dependencies,
             package_version: package_version.clone(),
-            no_cache,
+            no_cache: true,
             editable,
             source_path,
             source_uri,

--- a/crates/r2x-cli/src/commands/plugins/list.rs
+++ b/crates/r2x-cli/src/commands/plugins/list.rs
@@ -511,7 +511,7 @@ mod tests {
             return;
         }
 
-        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf(), None) else {
+        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf()) else {
             return;
         };
         let package = package_with_source(PackageSource::Pypi);
@@ -538,7 +538,7 @@ mod tests {
             return;
         }
 
-        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf(), None) else {
+        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf()) else {
             return;
         };
         let package = Package {
@@ -600,7 +600,7 @@ mod tests {
         let Ok(temp_dir) = TempDir::new() else {
             return;
         };
-        let Ok(locator) = PackageLocator::new(temp_dir.path().to_path_buf(), None) else {
+        let Ok(locator) = PackageLocator::new(temp_dir.path().to_path_buf()) else {
             return;
         };
 
@@ -621,7 +621,7 @@ mod tests {
         let mut package = package_with_source(PackageSource::Local);
         package.source_uri = Some(Arc::from(path_str.as_str()));
 
-        let Ok(locator) = PackageLocator::new(temp_dir.path().to_path_buf(), None) else {
+        let Ok(locator) = PackageLocator::new(temp_dir.path().to_path_buf()) else {
             return;
         };
 
@@ -650,7 +650,7 @@ mod tests {
             return;
         }
 
-        let Ok(locator) = PackageLocator::new(temp_dir.path().to_path_buf(), None) else {
+        let Ok(locator) = PackageLocator::new(temp_dir.path().to_path_buf()) else {
             return;
         };
 

--- a/crates/r2x-cli/src/commands/plugins/sync.rs
+++ b/crates/r2x-cli/src/commands/plugins/sync.rs
@@ -636,7 +636,7 @@ mod tests {
                 return None;
             }
         };
-        let locator = match PackageLocator::new(temp.path().to_path_buf(), None) {
+        let locator = match PackageLocator::new(temp.path().to_path_buf()) {
             Ok(locator) => locator,
             Err(err) => {
                 assert!(
@@ -734,7 +734,7 @@ mod tests {
             );
             return;
         }
-        let locator = match PackageLocator::new(site_packages, None) {
+        let locator = match PackageLocator::new(site_packages) {
             Ok(locator) => locator,
             Err(err) => {
                 assert!(

--- a/crates/r2x-cli/src/commands/read.rs
+++ b/crates/r2x-cli/src/commands/read.rs
@@ -1421,15 +1421,24 @@ shell(
     let stdin_is_tty = atty::is(Stream::Stdin);
     let stdout_is_tty = atty::is(Stream::Stdout);
     let interactive_prompt = stdin_is_tty && stdout_is_tty;
-    let (_tty_attached, stdin_tty, stdout_tty, stderr_tty) = acquire_tty_stdio();
+
+    // Only redirect stdio to /dev/tty when running interactively. In non-interactive
+    // contexts (tests, piped output) we must use inherited stdio so that Python's
+    // stderr (e.g. sidecar validation errors) reaches the caller's captured fd 2.
+    let (stdin_stdio, stdout_stdio, stderr_stdio) = if interactive_prompt {
+        let (_tty_attached, stdin_tty, stdout_tty, stderr_tty) = acquire_tty_stdio();
+        (stdin_tty, stdout_tty, stderr_tty)
+    } else {
+        (Stdio::inherit(), Stdio::inherit(), Stdio::inherit())
+    };
 
     // Spawn IPython bootstrap script with interactive embed
     let mut command = build_python_launch_command(&python_exe, &bootstrap_script);
 
     command
-        .stdin(stdin_tty)
-        .stdout(stdout_tty)
-        .stderr(stderr_tty);
+        .stdin(stdin_stdio)
+        .stdout(stdout_stdio)
+        .stderr(stderr_stdio);
 
     // Pass quiet and no-banner flags as environment variables
     if opts.quiet > 0 {

--- a/crates/r2x-cli/src/main.rs
+++ b/crates/r2x-cli/src/main.rs
@@ -9,6 +9,7 @@ use r2x::commands::{
 use r2x::common::GlobalOpts;
 use r2x_config as config_manager;
 use r2x_logger as logger;
+use r2x_python::python_bridge::process_exit;
 
 #[derive(Parser)]
 #[command(name = "r2x")]
@@ -266,10 +267,10 @@ fn main() {
                 logger::error(&format!("Run command failed: {}", e));
                 std::process::exit(1);
             }
-            // Exit directly to bypass PyO3's Python finalizer, which crashes
-            // when extension modules (numpy, scipy, etc.) have active background
-            // threads at process teardown.
-            std::process::exit(0);
+            // Re-acquire the GIL on the main thread before exit so that
+            // PyO3's atexit handler can call PyEval_SaveThread() without
+            // crashing. See python_bridge::process_exit for details.
+            process_exit(0);
         }
         Commands::Read(cmd) => {
             if let Err(e) = read::handle_read(cmd, cli.global) {

--- a/crates/r2x-cli/src/main.rs
+++ b/crates/r2x-cli/src/main.rs
@@ -266,6 +266,10 @@ fn main() {
                 logger::error(&format!("Run command failed: {}", e));
                 std::process::exit(1);
             }
+            // Exit directly to bypass PyO3's Python finalizer, which crashes
+            // when extension modules (numpy, scipy, etc.) have active background
+            // threads at process teardown.
+            std::process::exit(0);
         }
         Commands::Read(cmd) => {
             if let Err(e) = read::handle_read(cmd, cli.global) {

--- a/crates/r2x-cli/src/plugins/discovery.rs
+++ b/crates/r2x-cli/src/plugins/discovery.rs
@@ -38,44 +38,40 @@ pub fn discover_and_register_entry_points_with_deps(
     let no_cache = opts.no_cache;
     let package_version = opts.package_version.as_deref().unwrap_or("unknown");
 
-    // Check if we already have this package in the manifest with plugins
-    let has_cached_plugins = manifest
-        .get_package(package_name_full)
-        .is_some_and(|pkg| !pkg.plugins.is_empty());
-
     // Discover or use cached plugins
-    let discovered_plugins: Vec<Plugin> = if has_cached_plugins && !no_cache {
-        // Use cached plugins
-        manifest
-            .get_package(package_name_full)
-            .map(|pkg| pkg.plugins.clone())
-            .unwrap_or_default()
-    } else {
-        // Discover from source
-        let package_path =
-            resolve_package_path(locator, package_name_full, opts.source_path.as_deref())?;
+    let discovered_plugins: Vec<Plugin> =
+        if should_use_cached_plugins(manifest, package_name_full, package_version, no_cache) {
+            // Use cached plugins
+            manifest
+                .get_package(package_name_full)
+                .map(|pkg| pkg.plugins.clone())
+                .unwrap_or_default()
+        } else {
+            // Discover from source
+            let package_path =
+                resolve_package_path(locator, package_name_full, opts.source_path.as_deref())?;
 
-        logger::debug(&format!(
-            "Found package path for '{}': {}",
-            package_name_full,
-            package_path.display()
-        ));
+            logger::debug(&format!(
+                "Found package path for '{}': {}",
+                package_name_full,
+                package_path.display()
+            ));
 
-        let dist_info = locator.find_dist_info_path(package_name_full);
-        AstDiscovery::discover_plugins(
-            &package_path,
-            package_name_full,
-            venv_path,
-            Some(package_version),
-            dist_info.as_deref(),
-        )
-        .map_err(|e| {
-            PluginError::Discovery(format!(
-                "Failed to discover plugins for '{}': {}",
-                package, e
-            ))
-        })?
-    };
+            let dist_info = locator.find_dist_info_path(package_name_full);
+            AstDiscovery::discover_plugins(
+                &package_path,
+                package_name_full,
+                venv_path,
+                Some(package_version),
+                dist_info.as_deref(),
+            )
+            .map_err(|e| {
+                PluginError::Discovery(format!(
+                    "Failed to discover plugins for '{}': {}",
+                    package, e
+                ))
+            })?
+        };
 
     for plugin in &discovered_plugins {
         logger::debug(&format!(
@@ -194,6 +190,21 @@ pub fn discover_and_register_entry_points_with_deps(
     Ok(total_plugins)
 }
 
+fn should_use_cached_plugins(
+    manifest: &Manifest,
+    package_name_full: &str,
+    package_version: &str,
+    no_cache: bool,
+) -> bool {
+    if no_cache || package_version.is_empty() || package_version == "unknown" {
+        return false;
+    }
+
+    manifest
+        .get_package(package_name_full)
+        .is_some_and(|pkg| !pkg.plugins.is_empty() && pkg.version.as_ref() == package_version)
+}
+
 fn resolve_package_path(
     locator: &PackageLocator,
     package_name_full: &str,
@@ -230,7 +241,59 @@ fn resolve_package_path(
 #[cfg(test)]
 mod tests {
     use crate::plugins::discovery::*;
+    use r2x_manifest::types::{Manifest, Plugin, PluginType};
+    use std::sync::Arc;
     use tempfile::TempDir;
+
+    fn manifest_with_cached_plugin(version: &str) -> Manifest {
+        let mut manifest = Manifest::default();
+        let package = manifest.get_or_create_package("r2x-reeds");
+        package.version = Arc::from(version);
+        package.plugins.push(Plugin {
+            name: Arc::from("add-pcm-defaults"),
+            plugin_type: PluginType::Function,
+            module: Arc::from("stale.module"),
+            function_name: Some(Arc::from("add_pcm_defaults")),
+            ..Plugin::default()
+        });
+        manifest
+    }
+
+    #[test]
+    fn should_use_cached_plugins_only_for_matching_versions() {
+        let manifest = manifest_with_cached_plugin("0.5.0");
+
+        assert!(should_use_cached_plugins(
+            &manifest,
+            "r2x-reeds",
+            "0.5.0",
+            false
+        ));
+        assert!(!should_use_cached_plugins(
+            &manifest,
+            "r2x-reeds",
+            "0.6.0",
+            false
+        ));
+        assert!(!should_use_cached_plugins(
+            &manifest,
+            "r2x-reeds",
+            "0.5.0",
+            true
+        ));
+        assert!(!should_use_cached_plugins(
+            &manifest,
+            "r2x-reeds",
+            "unknown",
+            false
+        ));
+        assert!(!should_use_cached_plugins(
+            &manifest,
+            "r2x-reeds",
+            "",
+            false
+        ));
+    }
 
     #[test]
     fn test_resolve_package_path_prefers_source_path() {

--- a/crates/r2x-cli/src/plugins/discovery.rs
+++ b/crates/r2x-cli/src/plugins/discovery.rs
@@ -148,7 +148,7 @@ pub fn discover_and_register_entry_points_with_deps(
                         Err(e) => {
                             logger::warn(&format!(
                                 "Failed to discover plugins from dependency '{}': {}",
-                                &dep, e
+                                dep, e
                             ));
                             Vec::new()
                         }
@@ -157,7 +157,7 @@ pub fn discover_and_register_entry_points_with_deps(
                 Err(e) => {
                     logger::warn(&format!(
                         "Failed to locate dependency package '{}': {}",
-                        &dep, e
+                        dep, e
                     ));
                     Vec::new()
                 }

--- a/crates/r2x-cli/src/plugins/discovery.rs
+++ b/crates/r2x-cli/src/plugins/discovery.rs
@@ -307,7 +307,7 @@ mod tests {
                 return;
             }
         };
-        let locator = match PackageLocator::new(site_packages.path().to_path_buf(), None) {
+        let locator = match PackageLocator::new(site_packages.path().to_path_buf()) {
             Ok(locator) => locator,
             Err(err) => {
                 assert!(

--- a/crates/r2x-cli/tests/integration.rs
+++ b/crates/r2x-cli/tests/integration.rs
@@ -114,6 +114,54 @@ fn test_invalid_command() {
 }
 
 #[test]
+#[cfg(not(target_os = "windows"))]
+fn test_venv_create_creates_missing_default_venv_without_prompt_hint() {
+    let Some(uv_path) = find_tool(&["uv"]) else {
+        return;
+    };
+    let python_version = test_python_version();
+    if !uv_can_find_python(&uv_path, &python_version) {
+        return;
+    }
+
+    let Ok(temp_dir) = TempDir::new() else {
+        return;
+    };
+    let home = temp_dir.path();
+    let config_dir = home.join(".config").join("r2x");
+    if fs::create_dir_all(&config_dir).is_err() {
+        return;
+    }
+
+    let config_path = config_dir.join("config.toml");
+    if fs::write(
+        &config_path,
+        format!(
+            "uv_path = \"{}\"\npython_version = \"{}\"\n",
+            uv_path, python_version
+        ),
+    )
+    .is_err()
+    {
+        return;
+    }
+
+    let venv_path = config_dir.join(".venv");
+    let mut cmd = cargo_bin_cmd!("r2x");
+    cmd.env("HOME", home)
+        .env("R2X_CONFIG", &config_path)
+        .env("NO_COLOR", "1")
+        .args(["venv", "create"])
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("Virtual environment ready at"))
+        .stderr(predicate::str::contains("Failed to configure venv").not())
+        .stdout(predicate::str::contains("Use the `-y/--yes` flag").not());
+
+    assert!(venv_path.join("pyvenv.cfg").is_file());
+}
+
+#[test]
 fn test_plugins_help() {
     r2x_cmd()
         .args(["run", "plugin", "--help"])
@@ -875,6 +923,14 @@ fn find_tool(candidates: &[&str]) -> Option<String> {
         }
     }
     None
+}
+
+#[cfg(not(target_os = "windows"))]
+fn uv_can_find_python(uv_path: &str, python_version: &str) -> bool {
+    StdCommand::new(uv_path)
+        .args(["python", "find", python_version])
+        .output()
+        .is_ok_and(|output| output.status.success())
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/crates/r2x-cli/tests/integration.rs
+++ b/crates/r2x-cli/tests/integration.rs
@@ -149,6 +149,10 @@ fn test_venv_create_creates_missing_default_venv_without_prompt_hint() {
     let venv_path = config_dir.join(".venv");
     let mut cmd = cargo_bin_cmd!("r2x");
     cmd.env("HOME", home)
+        // Isolate XDG dirs so migrate_legacy_venv() cannot escape to the real
+        // runner home (e.g. via XDG_CONFIG_HOME set by the CI environment).
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("XDG_DATA_HOME", home.join(".local").join("share"))
         .env("R2X_CONFIG", &config_path)
         .env("NO_COLOR", "1")
         .args(["venv", "create"])

--- a/crates/r2x-manifest/src/package_discovery.rs
+++ b/crates/r2x-manifest/src/package_discovery.rs
@@ -25,11 +25,10 @@ struct DirectUrlMetadata {
     vcs_info: Option<DirectUrlVcsInfo>,
 }
 
-/// Resolve installed package paths from site-packages (optionally using UV cache).
+/// Resolve installed package paths from site-packages.
 #[derive(Debug, Clone)]
 pub struct PackageLocator {
     site_packages: PathBuf,
-    uv_cache_dir: Option<PathBuf>,
     /// Cached directory entries: filename -> full path
     dir_entries: HashMap<String, PathBuf>,
 }
@@ -46,7 +45,7 @@ impl PackageLocator {
     }
 
     /// Create a new locator for the given site-packages root.
-    pub fn new(site_packages: PathBuf, uv_cache_dir: Option<PathBuf>) -> Result<Self> {
+    pub fn new(site_packages: PathBuf) -> Result<Self> {
         debug!("Initializing package locator for: {:?}", site_packages);
 
         if !site_packages.exists() {
@@ -60,7 +59,6 @@ impl PackageLocator {
 
         Ok(PackageLocator {
             site_packages,
-            uv_cache_dir,
             dir_entries,
         })
     }
@@ -283,54 +281,31 @@ impl PackageLocator {
     }
 
     fn find_package_path_via_pth(&self, normalized_package_name: &str) -> Option<PathBuf> {
-        let cache_dir = self.uv_cache_dir.as_ref()?;
-        if !cache_dir.exists() {
-            return None;
-        }
+        // Editable installs create __editable__.{package}-{version}.pth in site-packages.
+        // Search site-packages directly — the uv archive cache (archive-v0) holds raw wheel
+        // contents and must NOT be used here, because wheels that ship their own .pth files
+        // (e.g. namespace packages) would be falsely classified as Local.
+        let entries = fs::read_dir(&self.site_packages).ok()?;
+        for entry in entries.flatten() {
+            let file_name = entry.file_name().to_string_lossy().to_string();
+            let matches = (file_name.starts_with("__editable__.")
+                && file_name.contains(&format!("{}-", normalized_package_name))
+                && file_name.ends_with(".pth"))
+                || file_name == format!("{}.pth", normalized_package_name);
 
-        let hash_dirs = fs::read_dir(cache_dir).ok()?;
-        for hash_entry in hash_dirs {
-            let hash_entry = match hash_entry {
-                Ok(entry) => entry,
-                Err(_) => continue,
-            };
-
-            let hash_path = hash_entry.path();
-            if !hash_path.is_dir() {
+            if !matches {
                 continue;
             }
 
-            let pth_entries = match fs::read_dir(&hash_path) {
-                Ok(entries) => entries,
-                Err(_) => continue,
-            };
-
-            for pth_entry in pth_entries {
-                let pth_entry = match pth_entry {
-                    Ok(entry) => entry,
-                    Err(_) => continue,
-                };
-
-                let pth_file_name = pth_entry.file_name().to_string_lossy().to_string();
-                let matches = pth_file_name == format!("{}.pth", normalized_package_name)
-                    || (pth_file_name.starts_with("__editable__.")
-                        && pth_file_name.contains(&format!("{}-", normalized_package_name))
-                        && pth_file_name.ends_with(".pth"));
-
-                if !matches {
-                    continue;
-                }
-
-                if let Ok(content) = fs::read_to_string(pth_entry.path()) {
-                    for line in content.lines() {
-                        let line = line.trim();
-                        if line.is_empty() || line.starts_with('#') {
-                            continue;
-                        }
-                        let candidate = PathBuf::from(line);
-                        if candidate.exists() {
-                            return Some(candidate);
-                        }
+            if let Ok(content) = fs::read_to_string(entry.path()) {
+                for line in content.lines() {
+                    let line = line.trim();
+                    if line.is_empty() || line.starts_with('#') {
+                        continue;
+                    }
+                    let candidate = PathBuf::from(line);
+                    if candidate.exists() {
+                        return Some(candidate);
                     }
                 }
             }
@@ -691,7 +666,7 @@ other = other.module:func
             return;
         }
 
-        let locator = match PackageLocator::new(site_packages.to_path_buf(), None) {
+        let locator = match PackageLocator::new(site_packages.to_path_buf()) {
             Ok(locator) => locator,
             Err(err) => {
                 assert!(
@@ -743,7 +718,7 @@ other = other.module:func
             return;
         }
 
-        let locator = match PackageLocator::new(site_packages.to_path_buf(), None) {
+        let locator = match PackageLocator::new(site_packages.to_path_buf()) {
             Ok(locator) => locator,
             Err(err) => {
                 assert!(
@@ -789,7 +764,7 @@ other = other.module:func
         };
         let site_packages = temp_dir.path();
 
-        let mut locator = match PackageLocator::new(site_packages.to_path_buf(), None) {
+        let mut locator = match PackageLocator::new(site_packages.to_path_buf()) {
             Ok(locator) => locator,
             Err(err) => {
                 assert!(
@@ -868,7 +843,7 @@ reeds = r2x_reeds.plugins:register_plugin
             return;
         }
 
-        let locator = match PackageLocator::new(site_packages.to_path_buf(), None) {
+        let locator = match PackageLocator::new(site_packages.to_path_buf()) {
             Ok(locator) => locator,
             Err(err) => {
                 assert!(
@@ -920,7 +895,7 @@ foo = bar.baz:qux
             return;
         }
 
-        let locator = match PackageLocator::new(site_packages.to_path_buf(), None) {
+        let locator = match PackageLocator::new(site_packages.to_path_buf()) {
             Ok(locator) => locator,
             Err(err) => {
                 assert!(
@@ -972,7 +947,7 @@ my_transform = r2x_transforms.transform:MyTransform
             return;
         }
 
-        let locator = match PackageLocator::new(site_packages.to_path_buf(), None) {
+        let locator = match PackageLocator::new(site_packages.to_path_buf()) {
             Ok(locator) => locator,
             Err(err) => {
                 assert!(
@@ -1011,7 +986,7 @@ my_transform = r2x_transforms.transform:MyTransform
             return;
         }
 
-        let locator = match PackageLocator::new(site_packages.to_path_buf(), None) {
+        let locator = match PackageLocator::new(site_packages.to_path_buf()) {
             Ok(locator) => locator,
             Err(err) => {
                 assert!(
@@ -1059,7 +1034,7 @@ my_transform = r2x_transforms.transform:MyTransform
             return;
         }
 
-        let locator = match PackageLocator::new(site_packages.to_path_buf(), None) {
+        let locator = match PackageLocator::new(site_packages.to_path_buf()) {
             Ok(locator) => locator,
             Err(err) => {
                 assert!(
@@ -1102,7 +1077,7 @@ my_transform = r2x_transforms.transform:MyTransform
             return;
         }
 
-        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf(), None) else {
+        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf()) else {
             return;
         };
 
@@ -1122,7 +1097,7 @@ my_transform = r2x_transforms.transform:MyTransform
             return;
         }
 
-        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf(), None) else {
+        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf()) else {
             return;
         };
 
@@ -1151,13 +1126,80 @@ my_transform = r2x_transforms.transform:MyTransform
             return;
         }
 
-        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf(), None) else {
+        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf()) else {
             return;
         };
 
         assert_eq!(
             locator.detect_package_source("r2x-sienna", None),
             PackageSource::Pypi
+        );
+    }
+
+    #[test]
+    fn test_pypi_package_with_wheel_pth_in_site_packages_stays_pypi() {
+        // Regression: some wheels ship a .pth file (e.g. for namespace packages).
+        // When uv installs such a wheel it places that .pth file in site-packages.
+        // If the path inside it doesn't point to an existing directory the package
+        // must still be classified as Pypi, not Local.
+        let Ok(temp_dir) = TempDir::new() else {
+            return;
+        };
+        let site_packages = temp_dir.path();
+        if fs::create_dir(site_packages.join("r2x_reeds-1.0.0.dist-info")).is_err() {
+            return;
+        }
+        // .pth file shipped by the wheel but path inside doesn't exist on disk
+        if fs::write(
+            site_packages.join("r2x_reeds.pth"),
+            "/nonexistent/path/that/does/not/exist\n",
+        )
+        .is_err()
+        {
+            return;
+        }
+
+        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf()) else {
+            return;
+        };
+
+        assert_eq!(
+            locator.detect_package_source("r2x-reeds", None),
+            PackageSource::Pypi
+        );
+    }
+
+    #[test]
+    fn test_editable_pth_in_site_packages_is_local() {
+        // uv creates __editable__.{pkg}-{version}.pth in site-packages for editable
+        // installs. That file must be detected and the package classified as Local.
+        let Ok(temp_dir) = TempDir::new() else {
+            return;
+        };
+        let site_packages = temp_dir.path();
+        let source_dir = site_packages.join("src");
+        if fs::create_dir(&source_dir).is_err() {
+            return;
+        }
+        if fs::create_dir(site_packages.join("r2x_reeds-1.0.0.dist-info")).is_err() {
+            return;
+        }
+        if fs::write(
+            site_packages.join("__editable__.r2x_reeds-1.0.0.pth"),
+            format!("{}\n", source_dir.display()),
+        )
+        .is_err()
+        {
+            return;
+        }
+
+        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf()) else {
+            return;
+        };
+
+        assert_eq!(
+            locator.detect_package_source("r2x-reeds", None),
+            PackageSource::Local
         );
     }
 
@@ -1181,7 +1223,7 @@ my_transform = r2x_transforms.transform:MyTransform
             return;
         }
 
-        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf(), None) else {
+        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf()) else {
             return;
         };
 
@@ -1213,7 +1255,7 @@ my_transform = r2x_transforms.transform:MyTransform
             return;
         }
 
-        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf(), None) else {
+        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf()) else {
             return;
         };
 
@@ -1242,7 +1284,7 @@ my_transform = r2x_transforms.transform:MyTransform
             return;
         }
 
-        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf(), None) else {
+        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf()) else {
             return;
         };
 
@@ -1266,7 +1308,7 @@ my_transform = r2x_transforms.transform:MyTransform
             return;
         }
 
-        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf(), None) else {
+        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf()) else {
             return;
         };
 
@@ -1285,7 +1327,7 @@ my_transform = r2x_transforms.transform:MyTransform
         }
         // No METADATA file
 
-        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf(), None) else {
+        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf()) else {
             return;
         };
 
@@ -1299,7 +1341,7 @@ my_transform = r2x_transforms.transform:MyTransform
         };
         let site_packages = temp_dir.path();
 
-        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf(), None) else {
+        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf()) else {
             return;
         };
 
@@ -1322,7 +1364,7 @@ my_transform = r2x_transforms.transform:MyTransform
             return;
         }
 
-        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf(), None) else {
+        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf()) else {
             return;
         };
 
@@ -1337,7 +1379,7 @@ my_transform = r2x_transforms.transform:MyTransform
         };
         let site_packages = temp_dir.path();
 
-        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf(), None) else {
+        let Ok(locator) = PackageLocator::new(site_packages.to_path_buf()) else {
             return;
         };
 

--- a/crates/r2x-python/src/python_bridge.rs
+++ b/crates/r2x-python/src/python_bridge.rs
@@ -35,6 +35,16 @@ static BRIDGE_INSTANCE: OnceCell<Result<Bridge, BridgeError>> = OnceCell::new();
 static POST_IMPORT_LOG_MODULES_ENABLED: Lazy<Mutex<HashSet<String>>> =
     Lazy::new(|| Mutex::new(HashSet::new()));
 
+/// Terminate the process safely when Python may be initialized.
+pub fn process_exit(code: i32) -> ! {
+    if BRIDGE_INSTANCE.get().is_some() {
+        // Give the main thread a thread state so Py_Finalize()'s
+        // PyEval_SaveThread() call can succeed.
+        Python::attach(|_py| -> ! { std::process::exit(code) });
+    }
+    std::process::exit(code)
+}
+
 impl Bridge {
     /// Get or initialize the bridge singleton
     pub fn get() -> Result<&'static Bridge, BridgeError> {

--- a/crates/r2x-python/src/python_bridge.rs
+++ b/crates/r2x-python/src/python_bridge.rs
@@ -70,12 +70,7 @@ impl Bridge {
             .map_err(|e| BridgeError::Initialization(format!("Failed to load config: {}", e)))?;
 
         // Ensure venv exists
-        let venv_path = PathBuf::from(config.get_venv_path());
-
-        if !venv_path.exists() {
-            // Create venv using the configured runtime Python version.
-            Self::create_venv(&config, &venv_path)?;
-        }
+        let venv_path = ensure_configured_venv(&mut config)?;
 
         // Resolve PYTHONHOME from venv's pyvenv.cfg
         let python_home = resolve_python_home(&venv_path)?;
@@ -137,70 +132,6 @@ impl Bridge {
         });
 
         Ok(Bridge { _marker: () })
-    }
-
-    /// Create a virtual environment
-    ///
-    /// Uses the configured runtime Python version. PyO3 is built with abi3-py311,
-    /// so the embedded extension ABI supports Python 3.11 and newer runtimes.
-    fn create_venv(config: &Config, venv_path: &PathBuf) -> Result<(), BridgeError> {
-        logger::step(&format!(
-            "Creating Python virtual environment at: {}",
-            venv_path.display()
-        ));
-
-        let python_version = runtime_python_version(config)?;
-
-        // Try uv first
-        if let Some(ref uv_path) = config.uv_path {
-            for python_query in python_version.query_candidates() {
-                let output = Command::new(uv_path)
-                    .arg("venv")
-                    .arg(venv_path)
-                    .arg("--python")
-                    .arg(python_query)
-                    .output()?;
-
-                if output.status.success() {
-                    logger::success("Virtual environment created successfully");
-                    return Ok(());
-                }
-
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                logger::debug_lazy(|| format!("uv venv failed for {python_query}: {}", stderr));
-            }
-        }
-
-        // Fallback to python3 -m venv
-        let python_cmd = format!("python{}", python_version.abi());
-        let output = Command::new(&python_cmd)
-            .args(["-m", "venv"])
-            .arg(venv_path)
-            .output();
-
-        if let Ok(output) = output {
-            if output.status.success() {
-                logger::success("Virtual environment created successfully");
-                return Ok(());
-            }
-        }
-
-        // Try generic python3
-        let output = Command::new("python3")
-            .args(["-m", "venv"])
-            .arg(venv_path)
-            .output()?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(BridgeError::Initialization(format!(
-                "Failed to create virtual environment: {}",
-                stderr
-            )));
-        }
-
-        logger::success("Virtual environment created successfully");
-        Ok(())
     }
 
     /// Configure PYTHONPATH to include site-packages
@@ -354,6 +285,16 @@ def _r2x_cache_path_override():
 
         Ok(())
     }
+}
+
+fn ensure_configured_venv(config: &mut Config) -> Result<PathBuf, BridgeError> {
+    let venv_path = config.ensure_venv_path().map_err(|error| {
+        BridgeError::Initialization(format!(
+            "Failed to ensure Python virtual environment: {}",
+            error
+        ))
+    })?;
+    Ok(PathBuf::from(venv_path))
 }
 
 fn pending_post_import_log_modules(modules: &[&str]) -> Vec<String> {
@@ -689,11 +630,10 @@ fn setup_windows_dll_path(python_version: &PythonRuntimeVersion) -> Result<(), B
 
 /// Configure the Python virtual environment (legacy API compatibility)
 pub fn configure_python_venv() -> Result<PythonEnvCompat, BridgeError> {
-    let config = Config::load()
+    let mut config = Config::load()
         .map_err(|e| BridgeError::Initialization(format!("Failed to load config: {}", e)))?;
 
-    let venv_path = PathBuf::from(config.get_venv_path());
-
+    let venv_path = ensure_configured_venv(&mut config)?;
     let interpreter = resolve_python_path(&venv_path)?;
     let python_home = resolve_python_home(&venv_path).ok();
 


### PR DESCRIPTION
## Summary
- create missing managed venvs through the shared config path before resolving Python
- only show the venv replacement prompt hint when a replacement prompt was actually shown
- refresh plugin metadata after installs, including same-version installs, so stale manifests do not drop function config bindings like PCMDefaultsConfig

## Validation
- cargo fmt --all
- PYO3_PYTHON="/Users/psanchez/.local/share/uv/python/cpython-3.12.12-macos-aarch64-none/bin/python3.12" cargo test --workspace --all-features
- PYO3_PYTHON="/Users/psanchez/.local/share/uv/python/cpython-3.12.12-macos-aarch64-none/bin/python3.12" cargo clippy --all --benches --tests --examples --all-features
- manual same-version stale manifest refresh for r2x-reeds==0.6.0
- manual r2x-reeds reeds-parser -> add-pcm-defaults pipeline