### PR TITLE
fix: satisfy Hawk visibility lints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,35 @@ jobs:
       - name: Clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
+  hawk:
+    name: Hawk visibility analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.97.1
+          rustflags: ""
+
+      - name: Setup uv & Python
+        uses: ./.github/actions/setup-uv-python
+        with:
+          python-version: "3.12"
+
+      - name: Install Hawk
+        env:
+          # renovate: datasource=github-releases depName=astral-sh/hawk
+          HAWK_VERSION: "0.1.9"
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            "https://github.com/astral-sh/hawk/releases/download/${HAWK_VERSION}/cargo-hawk-installer.sh" | sh
+
+      - name: Hawk
+        run: cargo +1.97.1 hawk check --target-dir target/hawk -D warnings
+
   test:
     name: Tests (${{ matrix.toolchain }}, Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/crates/r2x-artifacts/src/artifact_handoff.rs
+++ b/crates/r2x-artifacts/src/artifact_handoff.rs
@@ -83,7 +83,7 @@ pub fn parse_handoff_envelope(
     Ok(Some(envelope))
 }
 
-pub fn publish_handoff(
+pub(crate) fn publish_handoff(
     cache_root: &Path,
     bundle: &ArtifactBundle,
 ) -> Result<ArtifactHandoffEnvelope, ArtifactHandoffError> {
@@ -123,7 +123,7 @@ pub fn publish_handoff(
     ))
 }
 
-pub fn revoke_handoff(
+pub(crate) fn revoke_handoff(
     cache_root: &Path,
     envelope: &ArtifactHandoffEnvelope,
 ) -> Result<(), ArtifactHandoffError> {

--- a/crates/r2x-ast/src/discovery_types.rs
+++ b/crates/r2x-ast/src/discovery_types.rs
@@ -13,24 +13,19 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone)]
 pub struct EntryPointInfo {
     /// Entry point name (e.g., "reeds", "add-pcm-defaults")
-    pub name: String,
+    pub(crate) name: String,
     /// Module path (e.g., "r2x_reeds", "r2x_reeds.sysmod.pcm_defaults")
-    pub module: String,
+    pub(crate) module: String,
     /// Symbol name (e.g., "ReEDSParser", "add_pcm_defaults")
-    pub symbol: String,
+    pub(crate) symbol: String,
     /// Section name (e.g., "r2x_plugin", "r2x.transforms")
-    pub section: String,
+    pub(crate) section: String,
 }
 
 impl EntryPointInfo {
     /// Check if the symbol likely refers to a class (starts with uppercase)
-    pub fn is_class(&self) -> bool {
+    pub(crate) fn is_class(&self) -> bool {
         self.symbol.chars().next().is_some_and(|c| c.is_uppercase())
-    }
-
-    /// Get the full qualified entry point (module:symbol)
-    pub fn full_entry(&self) -> String {
-        format!("{}:{}", self.module, self.symbol)
     }
 }
 
@@ -40,24 +35,24 @@ impl EntryPointInfo {
 /// needed during AST discovery.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConfigSpec {
-    pub module: String,
-    pub name: String,
+    pub(crate) module: String,
+    pub(crate) name: String,
     #[serde(default)]
-    pub fields: Vec<ConfigField>,
+    pub(crate) fields: Vec<ConfigField>,
     /// Schema with nested type information for the config class.
     /// This includes recursively extracted properties for nested object types.
     #[serde(default, skip_serializing_if = "SchemaFields::is_empty")]
-    pub config_schema: SchemaFields,
+    pub(crate) config_schema: SchemaFields,
 }
 
 /// Configuration field specification (AST-specific)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConfigField {
-    pub name: String,
+    pub(crate) name: String,
     /// Array of type alternatives (for union types like int | str)
-    pub types: Vec<String>,
-    pub default: Option<String>,
-    pub required: bool,
+    pub(crate) types: Vec<String>,
+    pub(crate) default: Option<String>,
+    pub(crate) required: bool,
     /// Description extracted from Field(description="...")
-    pub description: Option<String>,
+    pub(crate) description: Option<String>,
 }

--- a/crates/r2x-ast/src/entry_points/mod.rs
+++ b/crates/r2x-ast/src/entry_points/mod.rs
@@ -6,5 +6,5 @@
 //!
 //! Entry points are the primary mechanism for discovering r2x plugins in installed packages.
 
-pub mod parser;
-pub mod pyproject;
+pub(crate) mod parser;
+pub(crate) mod pyproject;

--- a/crates/r2x-ast/src/entry_points/parser.rs
+++ b/crates/r2x-ast/src/entry_points/parser.rs
@@ -12,7 +12,7 @@ use r2x_logger as logger;
 /// - `[r2x.*]` - any section starting with "r2x." (e.g., r2x.transforms, r2x.parsers)
 ///
 /// Returns a vector of EntryPointInfo for all discovered entry points.
-pub fn parse_all_entry_points(content: &str) -> Vec<EntryPointInfo> {
+pub(crate) fn parse_all_entry_points(content: &str) -> Vec<EntryPointInfo> {
     let mut entries = Vec::new();
     let mut current_section: Option<String> = None;
 
@@ -52,12 +52,12 @@ pub fn parse_all_entry_points(content: &str) -> Vec<EntryPointInfo> {
 }
 
 /// Check if a section name is r2x-related
-pub fn is_r2x_section(section: &str) -> bool {
+pub(crate) fn is_r2x_section(section: &str) -> bool {
     section == "r2x_plugin" || section.starts_with("r2x.")
 }
 
 /// Parse a single entry point line in the format: name = module:symbol
-pub fn parse_entry_point_line(line: &str, section: &str) -> Option<EntryPointInfo> {
+pub(crate) fn parse_entry_point_line(line: &str, section: &str) -> Option<EntryPointInfo> {
     let eq_idx = line.find('=')?;
     let name = line[..eq_idx].trim();
     let value = line[eq_idx + 1..].trim();

--- a/crates/r2x-ast/src/entry_points/pyproject.rs
+++ b/crates/r2x-ast/src/entry_points/pyproject.rs
@@ -15,7 +15,10 @@ use std::path::{Path, PathBuf};
 /// 2. Parent of package_path
 /// 3. Parent of discovery_root
 /// 4. Grandparent of discovery_root
-pub fn find_pyproject_toml_path(package_path: &Path, discovery_root: &Path) -> Option<PathBuf> {
+pub(crate) fn find_pyproject_toml_path(
+    package_path: &Path,
+    discovery_root: &Path,
+) -> Option<PathBuf> {
     let mut seen = HashSet::new();
     let candidates = [
         Some(package_path),
@@ -42,7 +45,7 @@ pub fn find_pyproject_toml_path(package_path: &Path, discovery_root: &Path) -> O
 /// Parse entry points from pyproject.toml content (PEP 621 format)
 ///
 /// Looks for entry points in `[project.entry-points]` table.
-pub fn parse_pyproject_entry_points(content: &str) -> Vec<EntryPointInfo> {
+pub(crate) fn parse_pyproject_entry_points(content: &str) -> Vec<EntryPointInfo> {
     let mut entries = Vec::new();
     let parsed: toml::Value = match toml::from_str(content) {
         Ok(parsed) => parsed,

--- a/crates/r2x-ast/src/lib.rs
+++ b/crates/r2x-ast/src/lib.rs
@@ -10,9 +10,9 @@
 //! no Python interpreter startup.
 
 pub mod discovery_types;
-pub mod entry_points;
-pub mod naming;
-pub mod package_cache;
+pub(crate) mod entry_points;
+pub(crate) mod naming;
+pub(crate) mod package_cache;
 pub mod schema_extractor;
 
 use crate::discovery_types::{ConfigField, ConfigSpec, EntryPointInfo};

--- a/crates/r2x-ast/src/naming.rs
+++ b/crates/r2x-ast/src/naming.rs
@@ -13,7 +13,7 @@
 /// Handles acronyms (consecutive uppercase) correctly:
 /// - XMLParser -> xml-parser
 /// - HTTPClient -> http-client
-pub fn camel_to_kebab(class_name: &str) -> String {
+pub(crate) fn camel_to_kebab(class_name: &str) -> String {
     let mut result = String::new();
 
     for (i, ch) in class_name.chars().enumerate() {
@@ -50,7 +50,7 @@ pub fn camel_to_kebab(class_name: &str) -> String {
 }
 
 /// Convert snake_case function name to kebab-case plugin name
-pub fn snake_to_kebab(func_name: &str) -> String {
+pub(crate) fn snake_to_kebab(func_name: &str) -> String {
     func_name.replace('_', "-")
 }
 
@@ -58,7 +58,7 @@ pub fn snake_to_kebab(func_name: &str) -> String {
 ///
 /// Returns the index of the closing paren that matches the implicit opening paren
 /// at position -1 (i.e., we start at depth 0 looking for the first ')' at depth 0).
-pub fn find_matching_paren(text: &str) -> Option<usize> {
+pub(crate) fn find_matching_paren(text: &str) -> Option<usize> {
     let mut depth = 0;
     for (i, ch) in text.char_indices() {
         match ch {

--- a/crates/r2x-ast/src/package_cache.rs
+++ b/crates/r2x-ast/src/package_cache.rs
@@ -19,54 +19,33 @@ use walkdir::{DirEntry, WalkDir};
 
 /// Extracted class definition from a Python file
 #[derive(Debug, Clone)]
-pub struct ClassDef {
+pub(crate) struct ClassDef {
     /// Class name (e.g., "ReEDSParser")
-    pub name: String,
-    /// Base class names (e.g., ["Plugin[Config]", "BaseClass"])
-    pub bases: Vec<String>,
+    pub(crate) name: String,
     /// Generic parameter if Plugin[Config] form (e.g., "Config")
-    pub generic_param: Option<String>,
-    /// Method names defined in this class
-    pub methods: Vec<String>,
-    /// The raw class body text for further analysis
-    pub body_text: String,
+    pub(crate) generic_param: Option<String>,
 }
 
 /// Extracted function with @expose_plugin decorator
 #[derive(Debug, Clone)]
-pub struct DecoratedFunc {
+pub(crate) struct DecoratedFunc {
     /// Function name
-    pub function_name: String,
-    /// Raw parameter text for parsing
-    pub parameters_text: String,
-}
-
-/// Extracted field definition from a class
-#[derive(Debug, Clone)]
-pub struct FieldDef {
-    /// Field name
-    pub name: String,
-    /// Type annotation text
-    pub type_annotation: String,
-    /// Full field text including default value
-    pub full_text: String,
+    pub(crate) function_name: String,
 }
 
 /// Pre-parsed data for a single Python file
 #[derive(Debug)]
-pub struct ParsedPyFile {
-    /// File path
-    pub path: PathBuf,
+pub(crate) struct ParsedPyFile {
     /// Raw file content
-    pub content: String,
+    pub(crate) content: String,
     /// Extracted class definitions
-    pub classes: Vec<ClassDef>,
+    pub(crate) classes: Vec<ClassDef>,
     /// Functions decorated with @expose_plugin
-    pub decorated_functions: Vec<DecoratedFunc>,
+    decorated_functions: Vec<DecoratedFunc>,
 }
 
 /// Cache for a package - walk once, parse once, query many times
-pub struct PackageAstCache {
+pub(crate) struct PackageAstCache {
     /// Parsed files indexed by path
     files: HashMap<PathBuf, ParsedPyFile>,
     /// Index: class name -> file path
@@ -100,7 +79,7 @@ impl PackageAstCache {
     }
 
     /// Build cache by walking package once and parsing each .py file once
-    pub fn build(package_root: &Path) -> Self {
+    pub(crate) fn build(package_root: &Path) -> Self {
         let start = Instant::now();
         let mut files = HashMap::new();
         let mut class_index = HashMap::new();
@@ -154,7 +133,6 @@ impl PackageAstCache {
         ));
 
         ParsedPyFile {
-            path: path.to_path_buf(),
             content,
             classes,
             decorated_functions,
@@ -198,16 +176,11 @@ impl PackageAstCache {
                 }
             };
 
-            let (bases, generic_param) = Self::parse_bases(&bases_text);
-            let body_text = node.text().to_string();
-            let methods = Self::extract_method_names(&body_text);
+            let (_, generic_param) = Self::parse_bases(&bases_text);
 
             classes.push(ClassDef {
                 name,
-                bases,
                 generic_param,
-                methods,
-                body_text,
             });
         }
 
@@ -232,15 +205,9 @@ impl PackageAstCache {
                 continue;
             }
 
-            let body_text = node.text().to_string();
-            let methods = Self::extract_method_names(&body_text);
-
             classes.push(ClassDef {
                 name,
-                bases: Vec::new(),
                 generic_param: None,
-                methods,
-                body_text,
             });
         }
 
@@ -304,27 +271,6 @@ impl PackageAstCache {
         }
     }
 
-    /// Extract method names from class body text
-    fn extract_method_names(body_text: &str) -> Vec<String> {
-        let mut methods = Vec::new();
-
-        // Simple text-based extraction for method names
-        // Look for "def method_name(" patterns
-        for line in body_text.lines() {
-            let trimmed = line.trim();
-            if trimmed.starts_with("def ") {
-                if let Some(rest) = trimmed.strip_prefix("def ") {
-                    if let Some(paren_idx) = rest.find('(') {
-                        let method_name = rest[..paren_idx].trim();
-                        methods.push(method_name.to_string());
-                    }
-                }
-            }
-        }
-
-        methods
-    }
-
     /// Extract class name from class definition text
     /// Handles both "class Name:" and "class Name(Base):" forms
     fn extract_class_name_from_text(text: &str) -> String {
@@ -378,31 +324,13 @@ impl PackageAstCache {
                     .filter(|s| !s.is_empty())
                     .unwrap_or_else(|| Self::extract_function_name_from_text(&node.text()));
 
-                // Try to get parameters from metavariable, fallback to text extraction
-                let parameters_text = {
-                    let from_env: String = env
-                        .get_multiple_matches("$$$PARAMS")
-                        .iter()
-                        .map(|p| p.text().to_string())
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    if from_env.is_empty() {
-                        Self::extract_params_from_text(&node.text())
-                    } else {
-                        from_env
-                    }
-                };
-
                 if !function_name.is_empty() {
                     // Avoid duplicates
                     if !results
                         .iter()
                         .any(|r: &DecoratedFunc| r.function_name == function_name)
                     {
-                        results.push(DecoratedFunc {
-                            function_name,
-                            parameters_text,
-                        });
+                        results.push(DecoratedFunc { function_name });
                     }
                 }
             }
@@ -425,45 +353,13 @@ impl PackageAstCache {
         String::new()
     }
 
-    /// Extract parameters from function definition text
-    /// Handles "def name(param1, param2):" form
-    fn extract_params_from_text(text: &str) -> String {
-        // Find "def " and then the parentheses
-        if let Some(def_pos) = text.find("def ") {
-            let after_def = &text[def_pos..];
-            if let Some(open_paren) = after_def.find('(') {
-                // Find matching close paren (handle nested)
-                let params_start = &after_def[open_paren + 1..];
-                let mut depth = 1;
-                let mut end = 0;
-                for (i, ch) in params_start.char_indices() {
-                    match ch {
-                        '(' | '[' | '{' => depth += 1,
-                        ')' => {
-                            depth -= 1;
-                            if depth == 0 {
-                                end = i;
-                                break;
-                            }
-                        }
-                        ']' | '}' => depth -= 1,
-                        _ => {}
-                    }
-                }
-                if end > 0 {
-                    return params_start[..end].trim().to_string();
-                }
-            }
-        }
-        String::new()
-    }
-
     // =========================================================================
     // Query Methods - no re-walking or re-parsing
     // =========================================================================
 
     /// Find a class by name
-    pub fn find_class(&self, name: &str) -> Option<&ClassDef> {
+    #[cfg(test)]
+    fn find_class(&self, name: &str) -> Option<&ClassDef> {
         if let Some(path) = self.class_index.get(name) {
             if let Some(file) = self.files.get(path) {
                 return file.classes.iter().find(|c| c.name == name);
@@ -473,7 +369,7 @@ impl PackageAstCache {
     }
 
     /// Find a class and its file path by name
-    pub fn find_class_with_path(&self, name: &str) -> Option<(&PathBuf, &ClassDef)> {
+    pub(crate) fn find_class_with_path(&self, name: &str) -> Option<(&PathBuf, &ClassDef)> {
         if let Some(path) = self.class_index.get(name) {
             if let Some(file) = self.files.get(path) {
                 if let Some(class) = file.classes.iter().find(|c| c.name == name) {
@@ -484,27 +380,8 @@ impl PackageAstCache {
         None
     }
 
-    /// Find a Plugin class by symbol name
-    /// Returns (file_path, config_class_name) if found
-    pub fn find_plugin_class(&self, symbol: &str) -> Option<(&PathBuf, String)> {
-        if let Some((path, class)) = self.find_class_with_path(symbol) {
-            // Check if this class inherits from Plugin[...]
-            if let Some(ref config_name) = class.generic_param {
-                return Some((path, config_name.clone()));
-            }
-
-            // Also check bases directly for Plugin[Config] pattern
-            for base in &class.bases {
-                if let Some(param) = Self::extract_generic_param(base, "Plugin") {
-                    return Some((path, param));
-                }
-            }
-        }
-        None
-    }
-
     /// Find a config class by name and return its file content
-    pub fn find_config_class_content(&self, name: &str) -> Option<(&PathBuf, &str)> {
+    pub(crate) fn find_config_class_content(&self, name: &str) -> Option<(&PathBuf, &str)> {
         // First try the class index
         if let Some(path) = self.class_index.get(name) {
             if let Some(file) = self.files.get(path) {
@@ -525,7 +402,7 @@ impl PackageAstCache {
     }
 
     /// Get all @expose_plugin decorated functions from all files
-    pub fn get_all_decorated_functions(&self) -> Vec<(&PathBuf, &DecoratedFunc)> {
+    pub(crate) fn get_all_decorated_functions(&self) -> Vec<(&PathBuf, &DecoratedFunc)> {
         self.files
             .iter()
             .flat_map(|(path, file)| {
@@ -536,18 +413,13 @@ impl PackageAstCache {
             .collect()
     }
 
-    /// Get file content by path
-    pub fn get_file_content(&self, path: &Path) -> Option<&str> {
-        self.files.get(path).map(|f| f.content.as_str())
-    }
-
     /// Get all parsed files
-    pub fn files(&self) -> &HashMap<PathBuf, ParsedPyFile> {
+    pub(crate) fn files(&self) -> &HashMap<PathBuf, ParsedPyFile> {
         &self.files
     }
 
     /// Get the number of parsed files
-    pub fn file_count(&self) -> usize {
+    pub(crate) fn file_count(&self) -> usize {
         self.files.len()
     }
 }
@@ -557,36 +429,6 @@ mod tests {
     use crate::package_cache::*;
     use std::fs;
     use tempfile::TempDir;
-
-    #[test]
-    fn test_parse_bases() {
-        let (bases, generic) = PackageAstCache::parse_bases("Plugin[MyConfig], BaseClass");
-        assert_eq!(bases, vec!["Plugin[MyConfig]", "BaseClass"]);
-        assert_eq!(generic, Some("MyConfig".to_string()));
-
-        let (bases2, generic2) = PackageAstCache::parse_bases("BaseClass");
-        assert_eq!(bases2, vec!["BaseClass"]);
-        assert!(generic2.is_none());
-    }
-
-    #[test]
-    fn test_extract_method_names() {
-        let body = r"
-class MyClass:
-    def __init__(self):
-        pass
-
-    def process(self, data):
-        return data
-
-    def on_build(self, system):
-        pass
-";
-        let methods = PackageAstCache::extract_method_names(body);
-        assert!(methods.contains(&"__init__".to_string()));
-        assert!(methods.contains(&"process".to_string()));
-        assert!(methods.contains(&"on_build".to_string()));
-    }
 
     #[test]
     fn test_build_cache() -> anyhow::Result<()> {
@@ -621,15 +463,7 @@ def my_transform(system):
         // Check class extraction
         let class = cache.find_class("MyParser");
         assert!(class.is_some());
-        assert!(
-            class.is_some_and(|c| c.generic_param == Some("MyConfig".to_string())
-                && c.methods.contains(&"on_build".to_string()))
-        );
-
-        // Check Plugin class lookup
-        let plugin = cache.find_plugin_class("MyParser");
-        assert!(plugin.is_some());
-        assert!(plugin.is_some_and(|(_, config_name)| config_name == "MyConfig"));
+        assert!(class.is_some_and(|c| c.generic_param == Some("MyConfig".to_string())));
 
         // Check decorated function extraction
         let decorated = cache.get_all_decorated_functions();

--- a/crates/r2x-ast/src/schema_extractor.rs
+++ b/crates/r2x-ast/src/schema_extractor.rs
@@ -52,7 +52,7 @@ pub struct SchemaExtractor {
 
 impl SchemaExtractor {
     /// Create a new schema extractor
-    pub fn new() -> Self {
+    fn new() -> Self {
         SchemaExtractor {
             import_map: HashMap::new(),
             type_resolver: None,
@@ -60,17 +60,8 @@ impl SchemaExtractor {
         }
     }
 
-    /// Create a schema extractor with an import map for type resolution
-    pub fn with_imports(import_map: HashMap<String, String>) -> Self {
-        SchemaExtractor {
-            import_map,
-            type_resolver: None,
-            max_depth: DEFAULT_MAX_DEPTH,
-        }
-    }
-
     /// Create a schema extractor with a type resolver for nested type extraction
-    pub fn with_resolver(
+    pub(crate) fn with_resolver(
         import_map: HashMap<String, String>,
         resolver: Arc<dyn TypeResolver>,
     ) -> Self {
@@ -85,7 +76,7 @@ impl SchemaExtractor {
     ///
     /// Optimized to use a single AST parse - finds the class and extracts
     /// fields in one pass without re-parsing.
-    pub fn extract(&self, content: &str, class_name: &str) -> Result<SchemaFields> {
+    fn extract(&self, content: &str, class_name: &str) -> Result<SchemaFields> {
         let mut fields = SchemaFields::default();
 
         let sg = AstGrep::new(content, Python);
@@ -117,7 +108,11 @@ impl SchemaExtractor {
     ///
     /// # Returns
     /// SchemaFields with nested properties populated for object types
-    pub fn extract_with_nesting(&self, content: &str, class_name: &str) -> Result<SchemaFields> {
+    pub(crate) fn extract_with_nesting(
+        &self,
+        content: &str,
+        class_name: &str,
+    ) -> Result<SchemaFields> {
         let mut visited = std::collections::HashSet::new();
         self.extract_recursive(content, class_name, 0, &mut visited)
     }
@@ -506,7 +501,7 @@ fn find_first_arg_end(text: &str) -> Option<usize> {
 }
 
 /// Extract description from Field(description="...") or Field(..., description="...")
-pub fn extract_description_from_field(text: &str) -> Option<String> {
+pub(crate) fn extract_description_from_field(text: &str) -> Option<String> {
     if let Some(start) = text.find("description=") {
         let rest = &text[start + 12..];
         // Find opening quote
@@ -526,7 +521,7 @@ pub fn extract_description_from_field(text: &str) -> Option<String> {
 /// - "int | str | None" -> vec!["int", "str", "None"]
 /// - "Annotated[int | str, Field(...)]" -> vec!["int", "str"]
 /// - "str" -> vec!["str"]
-pub fn parse_union_types_from_annotation(annotation: &str) -> Vec<String> {
+pub(crate) fn parse_union_types_from_annotation(annotation: &str) -> Vec<String> {
     let annotation = annotation.trim();
 
     // Handle Annotated[X, Field(...)] - extract the actual type first

--- a/crates/r2x-cli/src/commands/config.rs
+++ b/crates/r2x-cli/src/commands/config.rs
@@ -366,7 +366,7 @@ pub fn handle_python(action: PythonAction, opts: GlobalOpts) {
 }
 
 /// Handle virtual environment management
-pub fn handle_venv(action: VenvAction, opts: GlobalOpts) {
+pub(crate) fn handle_venv(action: VenvAction, opts: GlobalOpts) {
     match action {
         VenvAction::Create { yes } => {
             handle_venv_create(yes);
@@ -378,7 +378,7 @@ pub fn handle_venv(action: VenvAction, opts: GlobalOpts) {
 }
 
 /// Handle cache management
-pub fn handle_cache(action: CacheAction, opts: GlobalOpts) {
+pub(crate) fn handle_cache(action: CacheAction, opts: GlobalOpts) {
     match action {
         CacheAction::Clean => {
             clean_cache(opts);
@@ -709,7 +709,7 @@ fn clean_cache(_opts: GlobalOpts) {
 /// Clean the configured cache folder.
 ///
 /// Shared by `r2x config cache clean` and `r2x clean`.
-pub fn clean_cache_folder() {
+pub(crate) fn clean_cache_folder() {
     match Config::load() {
         Ok(config) => {
             let cache_path = config.get_cache_path();

--- a/crates/r2x-cli/src/commands/plugins/context.rs
+++ b/crates/r2x-cli/src/commands/plugins/context.rs
@@ -6,12 +6,12 @@ use r2x_python::utils::resolve_site_package_path;
 use std::path::PathBuf;
 
 pub struct PluginContext {
-    pub config: Config,
-    pub manifest: Manifest,
-    pub uv_path: String,
-    pub venv_path: String,
-    pub python_path: String,
-    pub locator: PackageLocator,
+    pub(crate) config: Config,
+    pub(crate) manifest: Manifest,
+    pub(crate) uv_path: String,
+    pub(crate) venv_path: String,
+    pub(crate) python_path: String,
+    pub(crate) locator: PackageLocator,
 }
 
 impl PluginContext {
@@ -56,7 +56,7 @@ impl PluginContext {
         })
     }
 
-    pub fn refresh_locator(&mut self) -> Result<(), PluginError> {
+    pub(crate) fn refresh_locator(&mut self) -> Result<(), PluginError> {
         self.locator
             .refresh()
             .map_err(|e| PluginError::Locator(format!("Failed to refresh package locator: {e}")))

--- a/crates/r2x-cli/src/commands/read.rs
+++ b/crates/r2x-cli/src/commands/read.rs
@@ -15,23 +15,23 @@ use std::time::{SystemTime, UNIX_EPOCH};
 #[derive(Parser, Debug)]
 pub struct ReadCommand {
     /// Path to JSON or ZIP file to read. If not provided, reads from stdin
-    pub file: Option<PathBuf>,
+    file: Option<PathBuf>,
 
     /// Treat the input file as an infrasys ZIP archive
     #[arg(long)]
-    pub zip: bool,
+    zip: bool,
 
     /// Suppress the startup banner
     #[arg(long = "no-banner")]
-    pub no_banner: bool,
+    no_banner: bool,
 
     /// Execute a Python script against the loaded system
     #[arg(long = "exec", value_name = "SCRIPT")]
-    pub exec: Option<PathBuf>,
+    exec: Option<PathBuf>,
 
     /// Drop into interactive IPython session after script execution (use with --exec)
     #[arg(short = 'i', long = "interactive")]
-    pub interactive: bool,
+    interactive: bool,
 }
 
 pub fn handle_read(cmd: ReadCommand, opts: GlobalOpts) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/r2x-cli/src/commands/run/mod.rs
+++ b/crates/r2x-cli/src/commands/run/mod.rs
@@ -77,22 +77,22 @@ impl From<PipelineError> for RunError {
 #[derive(Parser, Debug)]
 pub struct RunCommand {
     #[command(subcommand)]
-    pub command: Option<RunSubcommand>,
+    command: Option<RunSubcommand>,
     #[arg(value_name = "YAML_PATH")]
-    pub yaml_path: Option<String>,
+    yaml_path: Option<String>,
     #[arg(value_name = "NAME")]
-    pub pipeline_name: Option<String>,
+    pipeline_name: Option<String>,
     #[arg(long)]
-    pub list: bool,
+    list: bool,
     #[arg(long)]
-    pub print: bool,
+    print: bool,
     #[arg(short = 'n', long)]
-    pub dry_run: bool,
+    dry_run: bool,
     #[arg(short = 'o', long, value_name = "FILE")]
-    pub output: Option<String>,
+    output: Option<String>,
     /// Save a system pipeline output as an infrasys ZIP archive
     #[arg(long)]
-    pub zip: bool,
+    zip: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -102,29 +102,29 @@ pub enum RunSubcommand {
 
 #[derive(Parser, Debug)]
 pub struct PluginCommand {
-    pub plugin_name: Option<String>,
+    plugin_name: Option<String>,
     #[arg(long)]
-    pub show_help: bool,
+    show_help: bool,
     #[arg(
         long,
         value_name = "FILE",
         help = "Write plugin JSON output to a UTF-8 file instead of stdout"
     )]
-    pub output: Option<String>,
+    output: Option<String>,
     #[arg(
         long,
         value_name = "N",
         default_value = "1",
         help = "Repeat plugin invocation N times"
     )]
-    pub repeat: NonZeroUsize,
+    repeat: NonZeroUsize,
     #[arg(
         long,
         help = "Print benchmark summary (also implied when --repeat > 1)"
     )]
-    pub benchmark: bool,
+    benchmark: bool,
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
-    pub args: Vec<String>,
+    args: Vec<String>,
 }
 
 pub fn handle_run(cmd: RunCommand, opts: GlobalOpts) -> Result<(), RunError> {
@@ -180,7 +180,7 @@ pub(super) fn build_call_target(bindings: &RuntimeBindings) -> Result<String, Ru
     Ok(target)
 }
 
-pub(super) fn format_duration(duration: Duration) -> String {
+fn format_duration(duration: Duration) -> String {
     let total_ms = duration.as_millis();
     if total_ms < 1000 {
         format!("{}ms", total_ms)
@@ -189,7 +189,7 @@ pub(super) fn format_duration(duration: Duration) -> String {
     }
 }
 
-pub(super) fn print_plugin_timing_breakdown(timings: &PluginInvocationTimings) {
+fn print_plugin_timing_breakdown(timings: &PluginInvocationTimings) {
     logger::debug(&format!(
         "Plugin python invocation {}",
         format_duration(timings.python_invocation)

--- a/crates/r2x-cli/src/commands/self_update.rs
+++ b/crates/r2x-cli/src/commands/self_update.rs
@@ -8,7 +8,7 @@ use crate::install_source::InstallSource;
 #[derive(Debug, Args)]
 pub struct SelfNamespace {
     #[command(subcommand)]
-    pub command: SelfCommand,
+    command: SelfCommand,
 }
 
 #[derive(Debug, Subcommand)]
@@ -21,16 +21,16 @@ pub enum SelfCommand {
 #[derive(Debug, Args)]
 pub struct SelfUpdateArgs {
     /// Update to the specified version. If not provided, r2x will update to the latest version.
-    pub target_version: Option<String>,
+    target_version: Option<String>,
 
     /// A GitHub token for authentication.
     /// A token is not required but can be used to reduce the chance of encountering rate limits.
     #[arg(long, env = "GITHUB_TOKEN")]
-    pub token: Option<String>,
+    token: Option<String>,
 
     /// Run without performing the update.
     #[arg(long)]
-    pub dry_run: bool,
+    dry_run: bool,
 }
 
 pub fn handle_self_command(args: SelfNamespace) -> Result<i32> {

--- a/crates/r2x-cli/src/common.rs
+++ b/crates/r2x-cli/src/common.rs
@@ -47,7 +47,7 @@ impl GlobalOpts {
     }
 
     /// Returns true when output (plugin stdout) should be fully suppressed
-    pub fn suppress_stdout(&self) -> bool {
+    pub(crate) fn suppress_stdout(&self) -> bool {
         self.quiet >= 2
     }
 }

--- a/crates/r2x-cli/src/help.rs
+++ b/crates/r2x-cli/src/help.rs
@@ -5,7 +5,7 @@ use r2x_manifest::types::Manifest;
 use std::collections::BTreeSet;
 
 /// Show help for the run command when invoked with no arguments
-pub fn show_run_help() -> Result<(), String> {
+pub(crate) fn show_run_help() -> Result<(), String> {
     let manifest = Manifest::load().map_err(|e| format!("Failed to load manifest: {}", e))?;
 
     println!();
@@ -56,7 +56,7 @@ pub fn show_run_help() -> Result<(), String> {
 }
 
 /// Show detailed help for a specific plugin
-pub fn show_plugin_help(plugin_name: &str) -> Result<(), String> {
+pub(crate) fn show_plugin_help(plugin_name: &str) -> Result<(), String> {
     let manifest = Manifest::load().map_err(|e| format!("Failed to load manifest: {}", e))?;
 
     let resolved = resolve_plugin_ref(&manifest, plugin_name).map_err(|e| e.to_string())?;

--- a/crates/r2x-cli/src/lib.rs
+++ b/crates/r2x-cli/src/lib.rs
@@ -5,7 +5,7 @@
 pub mod commands;
 pub mod common;
 pub mod errors;
-pub mod help;
+pub(crate) mod help;
 mod install_source;
 pub mod manifest_lookup;
 pub mod package_verification;

--- a/crates/r2x-cli/src/manifest_lookup.rs
+++ b/crates/r2x-cli/src/manifest_lookup.rs
@@ -38,12 +38,12 @@ impl fmt::Display for PluginRefError {
 
 impl std::error::Error for PluginRefError {}
 
-pub struct ResolvedPlugin<'a> {
-    pub package: &'a Package,
-    pub plugin: &'a Plugin,
+pub(crate) struct ResolvedPlugin<'a> {
+    pub(crate) package: &'a Package,
+    pub(crate) plugin: &'a Plugin,
 }
 
-pub fn resolve_plugin_ref<'a>(
+pub(crate) fn resolve_plugin_ref<'a>(
     manifest: &'a Manifest,
     plugin_ref: &str,
 ) -> Result<ResolvedPlugin<'a>, PluginRefError> {

--- a/crates/r2x-cli/src/package_verification.rs
+++ b/crates/r2x-cli/src/package_verification.rs
@@ -6,7 +6,6 @@ use r2x_config::Config;
 use r2x_logger as logger;
 use r2x_manifest::types::{Manifest, Package, PackageSource};
 use r2x_python::utils::resolve_site_package_path;
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -56,7 +55,7 @@ impl std::error::Error for VerificationError {}
 /// * `Ok(VerificationResult::Valid)` - All packages installed and valid
 /// * `Ok(VerificationResult::Missing(packages))` - List of missing/changed packages
 /// * `Err(VerificationError)` - Critical error during verification
-pub fn verify_plugin_packages(
+fn verify_plugin_packages(
     manifest: &Manifest,
     plugin_key: &str,
 ) -> Result<VerificationResult, VerificationError> {
@@ -155,32 +154,6 @@ fn dist_info_exists(site_packages: &Path, pattern: &str) -> bool {
     }
 
     false
-}
-
-/// Reinstall missing packages using uv
-///
-/// # Arguments
-/// * `packages` - List of package names to install
-/// * `config` - Configuration with uv path and venv settings
-///
-/// # Returns
-/// * `Ok(())` - Packages successfully installed
-/// * `Err(VerificationError)` - Installation failed
-pub fn ensure_packages(packages: Vec<String>, config: &Config) -> Result<(), VerificationError> {
-    if packages.is_empty() {
-        return Ok(());
-    }
-
-    logger::info(&format!(
-        "Installing missing packages: {}",
-        packages.join(", ")
-    ));
-
-    let python_exe = config.get_venv_python_path();
-    let package_refs: Vec<&str> = packages.iter().map(String::as_str).collect();
-    let install_args = build_pip_install_args(&python_exe, &package_refs, false);
-
-    run_pip_install(config, &install_args, packages.len())
 }
 
 fn ensure_manifest_package(package: &Package, config: &Config) -> Result<(), VerificationError> {
@@ -302,7 +275,7 @@ fn run_pip_install(
 ///
 /// // Now safe to run the plugin
 /// ```
-pub fn verify_and_ensure_plugin(
+pub(crate) fn verify_and_ensure_plugin(
     manifest: &Manifest,
     plugin_key: &str,
 ) -> Result<(), VerificationError> {
@@ -328,44 +301,6 @@ pub fn verify_and_ensure_plugin(
             Ok(())
         }
     }
-}
-
-/// Verify all packages in the manifest (for batch operations)
-///
-/// # Arguments
-/// * `manifest` - Plugin manifest to verify
-///
-/// # Returns
-/// Set of package names that need to be installed
-pub fn verify_all_packages(manifest: &Manifest) -> Result<HashSet<String>, VerificationError> {
-    let mut missing_packages = HashSet::new();
-
-    // Get venv path
-    let config = Config::load().map_err(|e| {
-        VerificationError::VerificationFailed(format!("Failed to load config: {}", e))
-    })?;
-    let venv_path = PathBuf::from(config.get_venv_path());
-
-    if !venv_path.exists() {
-        return Err(VerificationError::VenvNotFound(venv_path));
-    }
-
-    // Collect all unique package names from manifest
-    let mut all_packages: HashSet<String> = HashSet::new();
-    for pkg in &manifest.packages {
-        all_packages.insert(pkg.name.to_string());
-    }
-
-    // Check which packages are missing
-    let packages_vec: Vec<String> = all_packages.into_iter().collect();
-    let packages_refs: Vec<&str> = packages_vec.iter().map(|s| s.as_str()).collect();
-    let missing = check_packages_installed(&venv_path, &packages_refs)?;
-
-    for package in missing {
-        missing_packages.insert(package);
-    }
-
-    Ok(missing_packages)
 }
 
 #[cfg(test)]

--- a/crates/r2x-cli/src/pipeline_config.rs
+++ b/crates/r2x-cli/src/pipeline_config.rs
@@ -9,24 +9,24 @@ use std::path::{Path, PathBuf};
 pub struct PipelineConfig {
     /// Variables for substitution (${var} and $(var) syntax)
     #[serde(default)]
-    pub variables: HashMap<String, serde_yaml::Value>,
+    variables: HashMap<String, serde_yaml::Value>,
 
     /// Named pipelines (each is a list of plugin names)
     #[serde(default)]
-    pub pipelines: HashMap<String, Vec<String>>,
+    pipelines: HashMap<String, Vec<String>>,
 
     /// Output folder for pipeline results
     #[serde(default)]
-    pub output_folder: Option<String>,
+    pub(crate) output_folder: Option<String>,
 
     /// Plugin configuration (keyed by plugin name)
     #[serde(default)]
-    pub config: HashMap<String, serde_yaml::Value>,
+    pub(crate) config: HashMap<String, serde_yaml::Value>,
 }
 
 impl PipelineConfig {
     /// Load pipeline configuration from YAML file
-    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, PipelineError> {
+    pub(crate) fn load<P: AsRef<Path>>(path: P) -> Result<Self, PipelineError> {
         let path_ref = path.as_ref();
         let content = match fs::read_to_string(path_ref) {
             Ok(content) => content,
@@ -44,19 +44,19 @@ impl PipelineConfig {
     }
 
     /// List all available pipeline names
-    pub fn list_pipelines(&self) -> Vec<String> {
+    pub(crate) fn list_pipelines(&self) -> Vec<String> {
         let mut names: Vec<String> = self.pipelines.keys().cloned().collect();
         names.sort();
         names
     }
 
     /// Get a specific pipeline by name
-    pub fn get_pipeline(&self, name: &str) -> Option<&Vec<String>> {
+    pub(crate) fn get_pipeline(&self, name: &str) -> Option<&Vec<String>> {
         self.pipelines.get(name)
     }
 
     /// Substitute variables in a string (supports ${var} and $(var) syntax)
-    pub fn substitute_string(&self, input: &str) -> Result<String, PipelineError> {
+    pub(crate) fn substitute_string(&self, input: &str) -> Result<String, PipelineError> {
         let mut result = input.to_string();
 
         // Handle ${var} syntax
@@ -108,7 +108,7 @@ impl PipelineConfig {
     }
 
     /// Substitute variables in a YAML value recursively
-    pub fn substitute_value(
+    fn substitute_value(
         &self,
         value: &serde_yaml::Value,
     ) -> Result<serde_yaml::Value, PipelineError> {
@@ -139,7 +139,7 @@ impl PipelineConfig {
     }
 
     /// Get plugin configuration with variable substitution
-    pub fn get_plugin_config(&self, plugin_name: &str) -> Result<serde_yaml::Value, PipelineError> {
+    fn get_plugin_config(&self, plugin_name: &str) -> Result<serde_yaml::Value, PipelineError> {
         let config = self.config.get(plugin_name).ok_or_else(|| {
             PipelineError::InvalidConfig(format!(
                 "No configuration found for plugin '{}'",
@@ -151,24 +151,21 @@ impl PipelineConfig {
     }
 
     /// Get plugin configuration as JSON string (for Python bridge)
-    pub fn get_plugin_config_json(&self, plugin_name: &str) -> Result<String, PipelineError> {
+    pub(crate) fn get_plugin_config_json(
+        &self,
+        plugin_name: &str,
+    ) -> Result<String, PipelineError> {
         let config = self.get_plugin_config(plugin_name)?;
         serde_json::to_string(&config).map_err(|e| {
             PipelineError::InvalidConfig(format!("Failed to serialize config to JSON: {}", e))
         })
     }
 
-    /// Get all plugin configurations with variable substitution
-    pub fn get_all_configs(&self) -> Result<HashMap<String, serde_yaml::Value>, PipelineError> {
-        let mut configs = HashMap::new();
-        for (name, config) in &self.config {
-            configs.insert(name.clone(), self.substitute_value(config)?);
-        }
-        Ok(configs)
-    }
-
     /// Resolve and print the configuration for a specific pipeline
-    pub fn print_pipeline_config(&self, pipeline_name: &str) -> Result<String, PipelineError> {
+    pub(crate) fn print_pipeline_config(
+        &self,
+        pipeline_name: &str,
+    ) -> Result<String, PipelineError> {
         let pipeline = self
             .get_pipeline(pipeline_name)
             .ok_or_else(|| PipelineError::PipelineNotFound(pipeline_name.to_string()))?;

--- a/crates/r2x-cli/src/plugins/discovery.rs
+++ b/crates/r2x-cli/src/plugins/discovery.rs
@@ -12,21 +12,21 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Options for plugin discovery and registration
-pub struct DiscoveryOptions {
-    pub package: String,
-    pub package_name_full: String,
-    pub dependencies: Vec<String>,
-    pub package_version: Option<String>,
-    pub no_cache: bool,
-    pub editable: bool,
+pub(crate) struct DiscoveryOptions {
+    pub(crate) package: String,
+    pub(crate) package_name_full: String,
+    pub(crate) dependencies: Vec<String>,
+    pub(crate) package_version: Option<String>,
+    pub(crate) no_cache: bool,
+    pub(crate) editable: bool,
     /// Local filesystem path for editable installs (used for AST discovery)
-    pub source_path: Option<String>,
+    pub(crate) source_path: Option<String>,
     /// Display URI stored in manifest (git URL or local path)
-    pub source_uri: Option<String>,
+    pub(crate) source_uri: Option<String>,
 }
 
 /// Discover and register plugins from a package and its dependencies
-pub fn discover_and_register_entry_points_with_deps(
+pub(crate) fn discover_and_register_entry_points_with_deps(
     locator: &PackageLocator,
     venv_path: Option<&str>,
     manifest: &mut Manifest,

--- a/crates/r2x-cli/src/plugins/install.rs
+++ b/crates/r2x-cli/src/plugins/install.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 /// Query package info via a single pip show call.
 /// Returns (version, dependencies) tuple.
 /// Returns (None, empty_vec) on any error (best-effort, non-fatal).
-pub fn get_package_info(
+pub(crate) fn get_package_info(
     uv_path: &str,
     python_path: &str,
     package: &str,

--- a/crates/r2x-cli/src/plugins/mod.rs
+++ b/crates/r2x-cli/src/plugins/mod.rs
@@ -1,5 +1,5 @@
 // Core plugin infrastructure modules
-pub mod discovery;
+pub(crate) mod discovery;
 pub mod error;
-pub mod install;
-pub mod package_spec;
+pub(crate) mod install;
+pub(crate) mod package_spec;

--- a/crates/r2x-cli/src/plugins/package_spec.rs
+++ b/crates/r2x-cli/src/plugins/package_spec.rs
@@ -1,7 +1,7 @@
 use crate::plugins::error::PluginError;
 
 /// Check if a string looks like a local filesystem path.
-pub fn is_local_path(s: &str) -> bool {
+pub(crate) fn is_local_path(s: &str) -> bool {
     s.starts_with("./") || s.starts_with("../") || s.starts_with('/') || s == "." || s == ".."
 }
 
@@ -14,7 +14,7 @@ pub fn is_local_path(s: &str) -> bool {
 ///   - `https://github.com/org/repo`           (HTTPS without .git)
 ///   - `http://github.com/org/repo`            (HTTP)
 ///   - `git+ssh://...` / `git+https://...`     (pip-style prefixed)
-pub fn is_git_url(s: &str) -> bool {
+pub(crate) fn is_git_url(s: &str) -> bool {
     s.starts_with("git+")
         || s.starts_with("git@")
         || s.starts_with("ssh://")
@@ -23,7 +23,8 @@ pub fn is_git_url(s: &str) -> bool {
 }
 
 /// Check if a string uses the `gh:owner/repo` shorthand.
-pub fn is_github_shorthand(s: &str) -> bool {
+#[cfg(test)]
+fn is_github_shorthand(s: &str) -> bool {
     let Some(rest) = s.strip_prefix("gh:") else {
         return false;
     };
@@ -106,7 +107,7 @@ fn strip_git_ref(url: &str) -> &str {
 ///   - `https://github.com/org/R2X.git@main` → `R2X`
 ///   - `git+ssh://git@host/org/R2X.git`      → `R2X`
 ///   - `r2x-reeds`                            → `r2x-reeds`
-pub fn extract_package_name(package: &str) -> Result<String, PluginError> {
+pub(crate) fn extract_package_name(package: &str) -> Result<String, PluginError> {
     let pkg = strip_git_ref(package);
 
     if let Some(repo_path) = pkg.strip_prefix("gh:") {
@@ -152,7 +153,7 @@ pub fn extract_package_name(package: &str) -> Result<String, PluginError> {
 /// Build package specifier for pip install.
 ///
 /// Handles PyPI packages, local paths, git URLs (any format), and `gh:owner/repo` shorthand.
-pub fn build_package_spec(
+pub(crate) fn build_package_spec(
     package: &str,
     host: Option<String>,
     branch: Option<String>,

--- a/crates/r2x-config/src/lib.rs
+++ b/crates/r2x-config/src/lib.rs
@@ -188,7 +188,8 @@ impl Config {
         Ok(())
     }
 
-    pub fn is_empty(&self) -> bool {
+    #[cfg(test)]
+    fn is_empty(&self) -> bool {
         self.cache_path.is_none()
             && self.uv_path.is_none()
             && self.python_version.is_none()
@@ -198,38 +199,6 @@ impl Config {
             && self.no_stdout.is_none()
             && self.log_path.is_none()
             && self.log_max_size.is_none()
-    }
-
-    pub fn values_iter(&self) -> Vec<(&str, String)> {
-        let mut values = Vec::new();
-        if let Some(ref val) = self.cache_path {
-            values.push(("cache-path", val.clone()));
-        }
-        if let Some(ref val) = self.uv_path {
-            values.push(("uv-path", val.clone()));
-        }
-        if let Some(ref val) = self.python_version {
-            values.push(("python-version", val.clone()));
-        }
-        if let Some(ref val) = self.venv_path {
-            values.push(("venv-path", val.clone()));
-        }
-        if let Some(ref val) = self.r2x_core_version {
-            values.push(("r2x-core-version", val.clone()));
-        }
-        if let Some(val) = self.log_python {
-            values.push(("log-python", val.to_string()));
-        }
-        if let Some(val) = self.no_stdout {
-            values.push(("no-stdout", val.to_string()));
-        }
-        if let Some(ref val) = self.log_path {
-            values.push(("log-path", val.clone()));
-        }
-        if let Some(val) = self.log_max_size {
-            values.push(("log-max-size", val.to_string()));
-        }
-        values
     }
 
     pub fn reset() -> Result<(), ConfigError> {
@@ -608,7 +577,7 @@ impl PythonRuntimeVersion {
     }
 }
 
-pub fn runtime_python_version(
+fn runtime_python_version(
     configured_version: Option<&str>,
 ) -> Result<PythonRuntimeVersion, ConfigError> {
     let requested = match configured_version.map(str::trim) {

--- a/crates/r2x-logger/src/lib.rs
+++ b/crates/r2x-logger/src/lib.rs
@@ -35,7 +35,7 @@ pub fn get_log_python() -> bool {
 }
 
 /// Set whether Python logging to console is enabled
-pub fn set_log_python(enabled: bool) {
+fn set_log_python(enabled: bool) {
     if let Ok(mut v) = LOG_PYTHON.lock() {
         *v = enabled;
     }
@@ -47,15 +47,10 @@ pub fn get_no_stdout() -> bool {
 }
 
 /// Set whether stdout logging is disabled
-pub fn set_no_stdout(disabled: bool) {
+fn set_no_stdout(disabled: bool) {
     if let Ok(mut v) = NO_STDOUT.lock() {
         *v = disabled;
     }
-}
-
-/// Get the current plugin name being executed
-pub fn get_current_plugin() -> Option<String> {
-    CURRENT_PLUGIN.lock().ok().and_then(|guard| guard.clone())
 }
 
 /// Set the current plugin name being executed
@@ -63,21 +58,6 @@ pub fn set_current_plugin(plugin_name: Option<String>) {
     if let Ok(mut v) = CURRENT_PLUGIN.lock() {
         *v = plugin_name;
     }
-}
-
-/// Convert verbosity level to loguru log level string
-/// 0 = warn only, 1 = debug (-v), 2 = trace (-vv)
-pub fn verbosity_to_loguru_level() -> String {
-    match get_verbosity() {
-        0 => "WARNING".to_string(),
-        1 => "DEBUG".to_string(),
-        _ => "TRACE".to_string(),
-    }
-}
-
-/// Initialize the logger with a log file path and verbosity level
-pub fn init_with_verbosity(verbosity: u8, log_python: bool, no_stdout: bool) -> Result<(), String> {
-    init_with_config(verbosity, log_python, no_stdout, None, None)
 }
 
 /// Initialize logger with optional path override, file level, and max file size.
@@ -241,13 +221,6 @@ pub fn debug_lazy(message: impl FnOnce() -> String) {
     }
 }
 
-/// Log a debug message to console only (not to file)
-pub fn debug_console_only(message: &str) {
-    if get_verbosity() >= 1 {
-        eprintln!("{} {}", "DEBUG:".blue().bold(), message);
-    }
-}
-
 /// Log a warning message (to both file and console)
 pub fn warn(message: &str) {
     write_to_log(LogLevel::Warn, &format!("WARN {}", message));
@@ -340,17 +313,6 @@ pub fn get_log_path_string() -> String {
     }
 }
 
-/// Print the log file path to the user
-pub fn show_log_path() {
-    if let Some(path) = get_log_path() {
-        eprintln!("Log file: {}", path.display());
-    } else if let Ok(config_dir) = get_config_dir() {
-        eprintln!("Log file: {}", config_dir.join("r2x.log").display());
-    } else {
-        eprintln!("Log file location not available");
-    }
-}
-
 /// Start a spinner with the given message (only if not verbose)
 pub fn spinner_start(message: &str) {
     // Don't show spinner in verbose mode
@@ -405,15 +367,6 @@ pub fn spinner_error(message: &str) {
     }
     // Show error message with cross
     eprintln!("  {} {}", "✗".red().bold(), message);
-}
-
-/// Stop the spinner without any message
-pub fn spinner_stop() {
-    if let Ok(mut spinner_guard) = SPINNER.lock() {
-        if let Some(spinner) = spinner_guard.take() {
-            spinner.finish_and_clear();
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/r2x-manifest/src/lib.rs
+++ b/crates/r2x-manifest/src/lib.rs
@@ -18,5 +18,6 @@ pub mod errors;
 pub mod manifest;
 pub mod package_discovery;
 pub mod runtime;
-pub mod sync;
+#[cfg(test)]
+mod sync;
 pub mod types;

--- a/crates/r2x-manifest/src/manifest.rs
+++ b/crates/r2x-manifest/src/manifest.rs
@@ -4,7 +4,9 @@
 //! including CRUD operations, dependency tracking, and persistence.
 
 use crate::errors::ManifestError;
-use crate::types::{InstallType, Manifest, Package, PackageSource, Plugin};
+#[cfg(test)]
+use crate::types::Plugin;
+use crate::types::{InstallType, Manifest, Package, PackageSource};
 use smallvec::SmallVec;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -18,7 +20,7 @@ pub struct RemovedPackage {
 
 impl Manifest {
     /// Get the default path to the manifest file
-    pub fn path() -> PathBuf {
+    fn path() -> PathBuf {
         // On Unix/macOS: use ~/.cache/r2x/manifest.toml
         // On Windows: use AppData/Local/r2x/manifest.toml
         #[cfg(not(target_os = "windows"))]
@@ -45,7 +47,7 @@ impl Manifest {
     }
 
     /// Load manifest from a specific path
-    pub fn load_from_path(path: &Path) -> Result<Self, ManifestError> {
+    fn load_from_path(path: &Path) -> Result<Self, ManifestError> {
         if !path.exists() {
             return Ok(Manifest::default());
         }
@@ -63,7 +65,7 @@ impl Manifest {
     }
 
     /// Save manifest to a specific path with atomic write
-    pub fn save_to_path(&self, path: &Path) -> Result<(), ManifestError> {
+    fn save_to_path(&self, path: &Path) -> Result<(), ManifestError> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
@@ -100,7 +102,7 @@ impl Manifest {
 
     /// O(1) mutable package lookup by name
     #[inline]
-    pub fn get_package_mut(&mut self, name: &str) -> Option<&mut Package> {
+    fn get_package_mut(&mut self, name: &str) -> Option<&mut Package> {
         self.package_index
             .get(name)
             .copied()
@@ -136,7 +138,7 @@ impl Manifest {
     }
 
     /// Remove a package from the manifest
-    pub fn remove_package(&mut self, name: &str) -> bool {
+    fn remove_package(&mut self, name: &str) -> bool {
         if let Some(&idx) = self.package_index.get(name) {
             self.packages.remove(idx);
             self.rebuild_indexes();
@@ -146,38 +148,9 @@ impl Manifest {
         }
     }
 
-    /// Remove all plugins belonging to a package from the manifest
-    pub fn remove_plugins_by_package(&mut self, package_name: &str) -> usize {
-        if let Some(pkg) = self.get_package_mut(package_name) {
-            let count = pkg.plugins.len();
-            pkg.plugins.clear();
-            pkg.plugin_index.clear();
-            count
-        } else {
-            0
-        }
-    }
-
-    /// List all plugins (compatibility method) - returns (plugin_name, package_name) tuples
-    pub fn list_plugins(&self) -> Vec<(String, String)> {
-        self.packages
-            .iter()
-            .flat_map(|pkg| {
-                pkg.plugins
-                    .iter()
-                    .map(move |plugin| (plugin.name.to_string(), pkg.name.to_string()))
-            })
-            .collect()
-    }
-
     /// Check if manifest has no packages
     pub fn is_empty(&self) -> bool {
         self.packages.is_empty()
-    }
-
-    /// List all plugins across all packages (compatibility helper)
-    pub fn list_all_plugins(&self) -> Vec<(String, String)> {
-        self.list_plugins()
     }
 
     /// Count total plugins across all packages
@@ -267,68 +240,26 @@ impl Manifest {
 
     /// Remove a package and its dependencies if no other packages depend on them
     /// Returns list of packages removed
-    pub fn remove_package_with_deps(&mut self, package_name: &str) -> Vec<String> {
+    #[cfg(test)]
+    fn remove_package_with_deps(&mut self, package_name: &str) -> Vec<String> {
         self.remove_package_with_deps_summary(package_name)
             .into_iter()
             .map(|removed| removed.name)
             .collect()
-    }
-
-    /// Check if a package can be safely removed (has no dependents)
-    pub fn can_remove_package(&self, package_name: &str) -> bool {
-        // Check if any other package depends on this one
-        !self.packages.iter().any(|pkg| {
-            pkg.dependencies
-                .iter()
-                .any(|dep| dep.as_ref() == package_name)
-        })
-    }
-
-    /// Get all packages that depend on the given package
-    pub fn get_dependents(&self, package_name: &str) -> Vec<String> {
-        self.packages
-            .iter()
-            .filter(|pkg| {
-                pkg.dependencies
-                    .iter()
-                    .any(|dep| dep.as_ref() == package_name)
-            })
-            .map(|pkg| pkg.name.to_string())
-            .collect()
-    }
-
-    /// Serialize this Manifest to a JSON string
-    pub fn to_json_string(&self) -> String {
-        serde_json::to_string_pretty(&self).unwrap_or_else(|_| "{}".to_string())
-    }
-
-    /// Return the manifest JSON for CLI/UI consumers
-    pub fn get_manifest_json() -> String {
-        match Manifest::load() {
-            Ok(manifest) => manifest.to_json_string(),
-            Err(_) => "{}".to_string(),
-        }
     }
 }
 
 impl Package {
     /// Get a plugin by name with O(1) lookup
     #[inline]
-    pub fn get_plugin(&self, name: &str) -> Option<&Plugin> {
+    #[cfg(test)]
+    fn get_plugin(&self, name: &str) -> Option<&Plugin> {
         self.plugin_index.get(name).map(|&idx| &self.plugins[idx])
     }
 
-    /// Get a mutable plugin by name
-    #[inline]
-    pub fn get_plugin_mut(&mut self, name: &str) -> Option<&mut Plugin> {
-        self.plugin_index
-            .get(name)
-            .copied()
-            .map(move |idx| &mut self.plugins[idx])
-    }
-
     /// Add a plugin to the package
-    pub fn add_plugin(&mut self, plugin: Plugin) {
+    #[cfg(test)]
+    fn add_plugin(&mut self, plugin: Plugin) {
         let name = plugin.name.clone();
         let idx = self.plugins.len();
         self.plugins.push(plugin);
@@ -336,7 +267,8 @@ impl Package {
     }
 
     /// Remove a plugin from the package
-    pub fn remove_plugin(&mut self, name: &str) -> bool {
+    #[cfg(test)]
+    fn remove_plugin(&mut self, name: &str) -> bool {
         if let Some(&idx) = self.plugin_index.get(name) {
             self.plugins.remove(idx);
             self.rebuild_plugin_index();
@@ -350,7 +282,7 @@ impl Package {
 #[cfg(test)]
 mod tests {
     use crate::manifest::*;
-    use crate::types::PluginType;
+    use crate::types::{Plugin, PluginType};
 
     #[test]
     fn test_manifest_default() {

--- a/crates/r2x-manifest/src/package_discovery.rs
+++ b/crates/r2x-manifest/src/package_discovery.rs
@@ -70,12 +70,12 @@ impl PackageLocator {
     }
 
     /// Return the site-packages root used by this locator.
-    pub fn site_packages(&self) -> &Path {
+    fn site_packages(&self) -> &Path {
         &self.site_packages
     }
 
     /// Return an iterator over the cached directory entries (filename -> path).
-    pub fn dir_entries(&self) -> impl Iterator<Item = (&String, &PathBuf)> {
+    fn dir_entries(&self) -> impl Iterator<Item = (&String, &PathBuf)> {
         self.dir_entries.iter()
     }
 
@@ -97,7 +97,7 @@ impl PackageLocator {
     /// Find the `entry_points.txt` file for a given package.
     ///
     /// Returns the path if it exists inside the package's dist-info directory.
-    pub fn find_entry_points_txt(&self, package_name: &str) -> Option<PathBuf> {
+    fn find_entry_points_txt(&self, package_name: &str) -> Option<PathBuf> {
         let dist_info = self.find_dist_info_path(package_name)?;
         let entry_points = dist_info.join("entry_points.txt");
         if entry_points.exists() {
@@ -180,7 +180,8 @@ impl PackageLocator {
     /// Read the installed dependencies of a package from its `.dist-info/METADATA` file.
     ///
     /// Parses `Requires-Dist:` lines and returns bare package names (no version specifiers).
-    pub fn read_dependencies(&self, package_name: &str) -> Vec<String> {
+    #[cfg(test)]
+    fn read_dependencies(&self, package_name: &str) -> Vec<String> {
         let Some(dist_info) = self.find_dist_info_path(package_name) else {
             return Vec::new();
         };
@@ -533,7 +534,8 @@ impl<'a> PackageDiscoverer<'a> {
 }
 
 /// Parse entry_points.txt and extract r2x_plugin entry point
-pub fn parse_entry_points(entry_points_path: &Path) -> Result<(String, String)> {
+#[cfg(test)]
+fn parse_entry_points(entry_points_path: &Path) -> Result<(String, String)> {
     let content = fs::read_to_string(entry_points_path)?;
     let mut in_r2x_section = false;
     let mut module = String::new();

--- a/crates/r2x-manifest/src/runtime.rs
+++ b/crates/r2x-manifest/src/runtime.rs
@@ -100,7 +100,7 @@ fn plugin_role_from_group(group: &str) -> PluginRole {
 }
 
 /// Infer a legacy plugin role from name patterns when group metadata is absent.
-pub fn infer_plugin_role(name: &str) -> PluginRole {
+fn infer_plugin_role(name: &str) -> PluginRole {
     let name_lower = name.to_lowercase();
     if name_lower.contains("parser") {
         PluginRole::Parser

--- a/crates/r2x-manifest/src/sync.rs
+++ b/crates/r2x-manifest/src/sync.rs
@@ -17,11 +17,11 @@ use std::sync::Arc;
 
 /// Result of a sync operation
 #[derive(Debug, Default)]
-pub struct SyncResult {
-    pub packages_inserted: usize,
-    pub packages_updated: usize,
-    pub packages_unchanged: usize,
-    pub total_plugins: usize,
+pub(crate) struct SyncResult {
+    packages_inserted: usize,
+    packages_updated: usize,
+    packages_unchanged: usize,
+    total_plugins: usize,
 }
 
 // =============================================================================
@@ -30,10 +30,9 @@ pub struct SyncResult {
 
 /// Represents a change to be applied to the manifest
 #[derive(Debug)]
-pub enum Change {
+pub(crate) enum Change {
     Insert(Package),
     Update(Package),
-    Remove(Arc<str>),
 }
 
 // =============================================================================
@@ -43,45 +42,22 @@ pub enum Change {
 /// Engine for syncing packages to the manifest
 ///
 /// Uses parallel discovery and incremental updates with minimal locking
-pub struct SyncEngine {
+struct SyncEngine {
     manifest: Arc<RwLock<Manifest>>,
-    interner: StringInterner,
 }
 
 impl SyncEngine {
     /// Create a new sync engine with the given manifest
-    pub fn new(manifest: Manifest) -> Self {
+    fn new(manifest: Manifest) -> Self {
         SyncEngine {
             manifest: Arc::new(RwLock::new(manifest)),
-            interner: StringInterner::new(),
         }
-    }
-
-    /// Get a reference to the interner for string deduplication
-    pub fn interner(&self) -> &StringInterner {
-        &self.interner
-    }
-
-    /// Get a read lock on the manifest
-    pub fn manifest(&self) -> parking_lot::RwLockReadGuard<'_, Manifest> {
-        self.manifest.read()
-    }
-
-    /// Get a write lock on the manifest
-    pub fn manifest_mut(&self) -> parking_lot::RwLockWriteGuard<'_, Manifest> {
-        self.manifest.write()
-    }
-
-    /// Take ownership of the manifest
-    pub fn into_manifest(self) -> Manifest {
-        Arc::try_unwrap(self.manifest)
-            .map_or_else(|arc| arc.read().clone(), |lock| lock.into_inner())
     }
 
     /// Sync packages - HOT PATH
     ///
     /// Takes discovered packages and efficiently updates the manifest
-    pub fn sync_packages(&self, discovered: Vec<Package>) -> SyncResult {
+    fn sync_packages(&self, discovered: Vec<Package>) -> SyncResult {
         // 1. Compute hashes for all discovered packages in parallel
         let packages_with_hashes: Vec<Package> = discovered
             .into_par_iter()
@@ -103,7 +79,6 @@ impl SyncEngine {
             match change {
                 Change::Insert(_) => result.packages_inserted += 1,
                 Change::Update(_) => result.packages_updated += 1,
-                Change::Remove(_) => {}
             }
         }
         result.packages_unchanged =
@@ -154,38 +129,8 @@ impl SyncEngine {
                         }
                     }
                 }
-                Change::Remove(name) => {
-                    manifest.packages.retain(|p| p.name != name);
-                }
             }
         }
-    }
-
-    /// Update a single package in the manifest
-    pub fn update_package(&self, package: Package) {
-        let mut manifest = self.manifest.write();
-        if let Some(idx) = manifest
-            .packages
-            .iter()
-            .position(|p| p.name == package.name)
-        {
-            manifest.packages[idx] = package;
-        } else {
-            manifest.packages.push(package);
-        }
-        manifest.rebuild_indexes();
-    }
-
-    /// Remove a package from the manifest
-    pub fn remove_package(&self, name: &str) -> bool {
-        let mut manifest = self.manifest.write();
-        let initial_len = manifest.packages.len();
-        manifest.packages.retain(|p| p.name.as_ref() != name);
-        let removed = manifest.packages.len() < initial_len;
-        if removed {
-            manifest.rebuild_indexes();
-        }
-        removed
     }
 }
 
@@ -196,13 +141,13 @@ impl SyncEngine {
 /// String interner for deduplication
 ///
 /// Uses hash-based lookup for O(1) average case deduplication
-pub struct StringInterner {
+pub(crate) struct StringInterner {
     map: RwLock<AHashMap<u64, Arc<str>>>,
 }
 
 impl StringInterner {
     /// Create a new empty interner
-    pub fn new() -> Self {
+    fn new() -> Self {
         StringInterner {
             map: RwLock::new(AHashMap::new()),
         }
@@ -213,7 +158,7 @@ impl StringInterner {
     /// If the string already exists, returns the existing Arc.
     /// Otherwise, creates a new Arc and stores it.
     #[inline]
-    pub fn intern(&self, s: &str) -> Arc<str> {
+    fn intern(&self, s: &str) -> Arc<str> {
         use std::hash::{Hash, Hasher};
 
         let mut hasher = ahash::AHasher::default();
@@ -235,7 +180,7 @@ impl StringInterner {
 
     /// Intern a string that's already an Arc
     #[inline]
-    pub fn intern_arc(&self, s: Arc<str>) -> Arc<str> {
+    fn intern_arc(&self, s: Arc<str>) -> Arc<str> {
         use std::hash::{Hash, Hasher};
 
         let mut hasher = ahash::AHasher::default();
@@ -256,18 +201,8 @@ impl StringInterner {
     }
 
     /// Get the number of interned strings
-    pub fn len(&self) -> usize {
+    fn len(&self) -> usize {
         self.map.read().len()
-    }
-
-    /// Check if the interner is empty
-    pub fn is_empty(&self) -> bool {
-        self.map.read().is_empty()
-    }
-
-    /// Clear all interned strings
-    pub fn clear(&self) {
-        self.map.write().clear();
     }
 }
 

--- a/crates/r2x-manifest/src/types.rs
+++ b/crates/r2x-manifest/src/types.rs
@@ -391,28 +391,28 @@ impl Parameter {
 /// Configuration class definition
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConfigClass {
-    pub name: Arc<str>,
-    pub module: Arc<str>,
+    name: Arc<str>,
+    module: Arc<str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub base: Option<Arc<str>>,
+    base: Option<Arc<str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub base_module: Option<Arc<str>>,
+    base_module: Option<Arc<str>>,
     #[serde(default)]
-    pub fields: Vec<ConfigField>,
+    fields: Vec<ConfigField>,
 }
 
 /// Field definition within a config class
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConfigField {
-    pub name: Arc<str>,
+    name: Arc<str>,
     #[serde(rename = "type")]
-    pub field_type: Arc<str>,
+    field_type: Arc<str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub module: Option<Arc<str>>,
+    module: Option<Arc<str>>,
     #[serde(default)]
-    pub required: bool,
+    required: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default: Option<DefaultValue>,
+    default: Option<DefaultValue>,
 }
 
 // =============================================================================
@@ -432,7 +432,7 @@ impl Manifest {
 
 impl Package {
     /// Rebuild plugin index
-    pub fn rebuild_plugin_index(&mut self) {
+    pub(crate) fn rebuild_plugin_index(&mut self) {
         self.plugin_index.clear();
         for (idx, plugin) in self.plugins.iter().enumerate() {
             self.plugin_index.insert(plugin.name.clone(), idx);
@@ -440,7 +440,8 @@ impl Package {
     }
 
     /// Pre-compute hash for fast equality check
-    pub fn compute_hash(&mut self) {
+    #[cfg(test)]
+    pub(crate) fn compute_hash(&mut self) {
         use std::hash::{Hash, Hasher};
         let mut hasher = ahash::AHasher::default();
         self.name.hash(&mut hasher);

--- a/crates/r2x-python/src/plugin_invoker.rs
+++ b/crates/r2x-python/src/plugin_invoker.rs
@@ -174,29 +174,6 @@ impl crate::python_bridge::Bridge {
         Self::save_system_artifact_as_zip_native(input, output)
     }
 
-    /// Invoke a plugin using directory-backed input and output artifacts.
-    ///
-    /// Payload bytes remain in Python. In particular, Systems are loaded and
-    /// written through their path-aware Python APIs so sidecars stay adjacent
-    /// to the JSON entrypoint.
-    pub fn invoke_plugin_with_artifacts(
-        &self,
-        target: &str,
-        config_json: &str,
-        input: Option<&ArtifactBundle>,
-        output: &ArtifactBundle,
-        plugin_metadata: Option<&Plugin>,
-    ) -> Result<PluginArtifactInvocationResult, BridgeError> {
-        let runtime_bindings = plugin_metadata.map(build_runtime_bindings);
-        self.invoke_plugin_with_artifact_bindings(
-            target,
-            config_json,
-            input,
-            output,
-            runtime_bindings.as_ref(),
-        )
-    }
-
     /// Artifact-mode counterpart of [`Self::invoke_plugin_with_bindings`].
     pub fn invoke_plugin_with_artifact_bindings(
         &self,

--- a/crates/r2x-python/src/plugin_kwargs.rs
+++ b/crates/r2x-python/src/plugin_kwargs.rs
@@ -766,7 +766,7 @@ fn detect_missing_data_file_from_metadata(
     detect_missing_data_file_from_mapping(&class_obj, folder_path)
 }
 
-pub(crate) fn resolve_config_class<'py>(
+fn resolve_config_class<'py>(
     py: pyo3::Python<'py>,
     config_instance: Option<&pyo3::Bound<'py, PyAny>>,
     metadata: Option<&RuntimeConfig>,

--- a/crates/r2x-python/src/plugin_regular.rs
+++ b/crates/r2x-python/src/plugin_regular.rs
@@ -1210,7 +1210,7 @@ pub(crate) fn format_python_error(py: pyo3::Python<'_>, err: pyo3::PyErr, contex
 }
 
 /// Render a Python traceback to a string.
-pub(crate) fn render_traceback(py: pyo3::Python<'_>, err: &pyo3::PyErr) -> Option<String> {
+fn render_traceback(py: pyo3::Python<'_>, err: &pyo3::PyErr) -> Option<String> {
     let traceback = err.traceback(py)?;
     let traceback_module = PyModule::import(py, "traceback").ok()?;
     let formatter = traceback_module.getattr("format_exception").ok()?;
@@ -1225,7 +1225,7 @@ pub(crate) fn render_traceback(py: pyo3::Python<'_>, err: &pyo3::PyErr) -> Optio
 ///
 /// This is used for exceptions extracted from Result Err variants, where
 /// we have a Python object that is an exception but not a PyErr.
-pub(crate) fn format_exception_value(py: pyo3::Python<'_>, exc_value: &Bound<'_, PyAny>) -> String {
+fn format_exception_value(py: pyo3::Python<'_>, exc_value: &Bound<'_, PyAny>) -> String {
     // Try to extract traceback using Option chaining
     let traceback_text = (|| -> Option<String> {
         let tb = exc_value.getattr("__traceback__").ok()?;

--- a/crates/r2x-python/src/python_bridge.rs
+++ b/crates/r2x-python/src/python_bridge.rs
@@ -59,18 +59,6 @@ impl Bridge {
         }
     }
 
-    /// Check if Python is available without initializing
-    pub fn is_python_available() -> bool {
-        let config = match Config::load() {
-            Ok(c) => c,
-            Err(_) => return false,
-        };
-
-        // Check if venv exists and has valid pyvenv.cfg
-        let venv_path = PathBuf::from(config.get_venv_path());
-        venv_path.join("pyvenv.cfg").exists()
-    }
-
     /// Initialize Python interpreter and configure environment
     ///
     /// This performs:
@@ -266,7 +254,7 @@ def _r2x_cache_path_override():
     }
 
     /// Enable loguru logging for a list of Python modules
-    pub(crate) fn enable_loguru_modules(py: Python, modules: &[&str]) -> Result<(), BridgeError> {
+    fn enable_loguru_modules(py: Python, modules: &[&str]) -> Result<(), BridgeError> {
         let loguru = PyModule::import(py, "loguru")?;
         let logger_obj = loguru.getattr("logger")?;
 

--- a/crates/r2x-python/src/utils.rs
+++ b/crates/r2x-python/src/utils.rs
@@ -8,14 +8,16 @@ use crate::errors::BridgeError;
 use r2x_config::venv_paths::{resolve_python_exe, resolve_site_packages, VenvPathError};
 use std::path::{Path, PathBuf};
 
-pub const PYTHON_LIB_DIR: &str = r2x_config::venv_paths::PYTHON_LIB_DIR;
-pub const PYTHON_BIN_DIR: &str = r2x_config::venv_paths::PYTHON_BIN_DIR;
+#[cfg(test)]
+const PYTHON_LIB_DIR: &str = r2x_config::venv_paths::PYTHON_LIB_DIR;
+#[cfg(test)]
+const PYTHON_BIN_DIR: &str = r2x_config::venv_paths::PYTHON_BIN_DIR;
 
 pub fn resolve_site_package_path(venv_path: &Path) -> Result<PathBuf, BridgeError> {
     resolve_site_packages(venv_path).map_err(venv_path_error_to_bridge_error)
 }
 
-pub fn resolve_python_path(venv_path: &Path) -> Result<PathBuf, BridgeError> {
+pub(crate) fn resolve_python_path(venv_path: &Path) -> Result<PathBuf, BridgeError> {
     resolve_python_exe(venv_path).map_err(venv_path_error_to_bridge_error)
 }
 

--- a/hawk.toml
+++ b/hawk.toml
@@ -1,0 +1,27 @@
+# Keep intentional uniform field visibility audited instead of excluding whole files.
+preserve-uniform-field-visibility = true
+
+[[production]]
+package = "r2x"
+bin = "r2x"
+reason = "shipped command-line application"
+
+# These helpers are used by the Windows Python DLL setup, which is outside
+# the host-target analysis performed in CI.
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "r2x_config"
+item = "PythonRuntimeVersion::install_hint"
+kind = "inherent_method"
+level = "expect"
+target = "cfg(not(windows))"
+reason = "used by the Windows Python runtime setup"
+
+[[override]]
+lint = "hawk::unnecessary_public"
+crate = "r2x_config"
+item = "PythonRuntimeVersion::find_hint"
+kind = "inherent_method"
+level = "expect"
+target = "cfg(not(windows))"
+reason = "used by the Windows Python runtime setup"


### PR DESCRIPTION
## Summary
- configure Hawk for the shipped `r2x` binary
- reduce unnecessary public and restricted visibility across workspace crates
- remove unreachable public APIs and dead internal helpers
- enforce Hawk with `-D warnings` in CI

## Validation
- `cargo +1.97.1 hawk check --target-dir target/hawk -D warnings`
- `R2X_PYTHON_VERSION=3.12 cargo +1.97.1 test --workspace --all-features --locked`
- `R2X_PYTHON_VERSION=3.12 cargo +1.97.1 clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo +1.97.1 fmt --all -- --check`