### PR TITLE
fix(cli): preserve time-series sidecars in inline handoffs

### DIFF
--- a/crates/r2x-cli/src/commands/run/pipeline/overrides.rs
+++ b/crates/r2x-cli/src/commands/run/pipeline/overrides.rs
@@ -3,7 +3,7 @@ use r2x_config::Config;
 use r2x_logger as logger;
 use r2x_manifest::runtime::RuntimeBindings;
 use r2x_python::plugin_invoker::ArtifactBundle;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::commands::run::pipeline::constants::JSON_PATH_FIELDS;
@@ -117,7 +117,21 @@ fn persist_pipeline_system_json(payload: &str) -> Result<String, RunError> {
         .ensure_cache_path()
         .map_err(|e| RunError::Config(e.to_string()))?;
     let dir = PathBuf::from(cache_root).join("pipeline-systems");
-    std::fs::create_dir_all(&dir)
+    persist_pipeline_system_json_at(
+        payload,
+        &dir,
+        &std::env::current_dir().map_err(|e| {
+            RunError::Config(format!("Failed to determine current directory: {}", e))
+        })?,
+    )
+}
+
+fn persist_pipeline_system_json_at(
+    payload: &str,
+    destination_dir: &Path,
+    sidecar_parent_dir: &Path,
+) -> Result<String, RunError> {
+    std::fs::create_dir_all(destination_dir)
         .map_err(PipelineError::Io)
         .map_err(RunError::Pipeline)?;
 
@@ -131,15 +145,147 @@ fn persist_pipeline_system_json(payload: &str) -> Result<String, RunError> {
         std::process::id(),
         rand_suffix()
     );
-    let path = dir.join(filename);
-    std::fs::write(&path, payload)
+    let path = destination_dir.join(filename);
+
+    // Inline pipeline payloads only contain JSON. If a System references a
+    // relative or absolute time-series sidecar, copy a self-contained bundle
+    // next to the persisted JSON and make the reference relative to it.
+    // Otherwise the next plugin can deserialize the JSON but cannot resolve
+    // its attached time series.
+    let mut persisted = serde_json::from_str::<serde_json::Value>(payload).ok();
+    if let Some(ref mut value) = persisted {
+        if let Some(time_series) = time_series_metadata_mut(value) {
+            if let Some(directory) = time_series.get("directory").and_then(|v| v.as_str()) {
+                let source = PathBuf::from(directory);
+                let source = if source.is_absolute() {
+                    source
+                } else {
+                    sidecar_parent_dir.join(source)
+                };
+                if source.is_dir() {
+                    let sidecar_name = format!(
+                        "{}_time_series",
+                        path.file_stem().unwrap().to_string_lossy()
+                    );
+                    let destination = destination_dir.join(&sidecar_name);
+                    copy_sidecar_directory(&source, &destination)?;
+                    time_series.insert(
+                        "directory".to_string(),
+                        serde_json::Value::String(sidecar_name),
+                    );
+                }
+            }
+        }
+    }
+
+    let output = persisted
+        .as_ref()
+        .map(serde_json::Value::to_string)
+        .unwrap_or_else(|| payload.to_string());
+    std::fs::write(&path, output)
         .map_err(PipelineError::Io)
         .map_err(RunError::Pipeline)?;
     Ok(path.to_string_lossy().to_string())
+}
+
+fn time_series_metadata_mut(
+    value: &mut serde_json::Value,
+) -> Option<&mut serde_json::Map<String, serde_json::Value>> {
+    let object = value.as_object_mut()?;
+    if object.contains_key("time_series") {
+        return object
+            .get_mut("time_series")
+            .and_then(serde_json::Value::as_object_mut);
+    }
+
+    if object.contains_key("system") {
+        return object.get_mut("system").and_then(time_series_metadata_mut);
+    }
+    object.get_mut("data").and_then(time_series_metadata_mut)
+}
+
+fn copy_sidecar_directory(source: &Path, destination: &Path) -> Result<(), RunError> {
+    std::fs::create_dir_all(destination)
+        .map_err(PipelineError::Io)
+        .map_err(RunError::Pipeline)?;
+    for entry in std::fs::read_dir(source)
+        .map_err(PipelineError::Io)
+        .map_err(RunError::Pipeline)?
+    {
+        let entry = entry
+            .map_err(PipelineError::Io)
+            .map_err(RunError::Pipeline)?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let metadata = std::fs::symlink_metadata(&source_path)
+            .map_err(PipelineError::Io)
+            .map_err(RunError::Pipeline)?;
+        if metadata.file_type().is_symlink() {
+            return Err(RunError::Config(format!(
+                "Time-series sidecar contains unsupported symlink: {}",
+                source_path.display()
+            )));
+        }
+        if metadata.is_dir() {
+            copy_sidecar_directory(&source_path, &destination_path)?;
+        } else if metadata.is_file() {
+            std::fs::copy(&source_path, &destination_path)
+                .map_err(PipelineError::Io)
+                .map_err(RunError::Pipeline)?;
+        } else {
+            return Err(RunError::Config(format!(
+                "Time-series sidecar contains unsupported filesystem entry: {}",
+                source_path.display()
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn rand_suffix() -> u32 {
     use std::sync::atomic::{AtomicU32, Ordering};
     static COUNTER: AtomicU32 = AtomicU32::new(0);
     COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::persist_pipeline_system_json_at;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn persists_inline_system_with_relative_time_series_sidecar() {
+        let source = tempdir().unwrap();
+        let sidecar = source.path().join("system_time_series");
+        fs::create_dir(&sidecar).unwrap();
+        fs::write(sidecar.join("time_series_metadata.db"), b"metadata").unwrap();
+
+        let destination = tempdir().unwrap();
+        let payload = serde_json::json!({
+            "components": [],
+            "time_series": { "directory": "system_time_series" }
+        })
+        .to_string();
+
+        let persisted =
+            persist_pipeline_system_json_at(&payload, destination.path(), source.path()).unwrap();
+        let persisted_path = std::path::PathBuf::from(persisted);
+        let persisted_json: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&persisted_path).unwrap()).unwrap();
+        let directory = persisted_json["time_series"]["directory"].as_str().unwrap();
+
+        assert!(!std::path::Path::new(directory).is_absolute());
+        assert_eq!(
+            fs::read(
+                persisted_path
+                    .parent()
+                    .unwrap()
+                    .join(directory)
+                    .join("time_series_metadata.db")
+            )
+            .unwrap(),
+            b"metadata"
+        );
+    }
 }

--- a/crates/r2x-python/src/plugin_regular.rs
+++ b/crates/r2x-python/src/plugin_regular.rs
@@ -9,7 +9,7 @@ use crate::python_bridge::Bridge;
 use once_cell::sync::Lazy;
 use pyo3::exceptions::PyValueError;
 use pyo3::types::{PyAny, PyAnyMethods, PyBytes, PyDict, PyDictMethods, PyModule};
-use pyo3::{Bound, PyResult};
+use pyo3::{Bound, Py, PyResult};
 use r2x_logger as logger;
 use r2x_manifest::runtime::{PluginRole, RuntimeBindings};
 use std::collections::HashMap;
@@ -336,7 +336,7 @@ impl Bridge {
 
             logger::debug("Starting plugin invocation");
             let call_start = Instant::now();
-            let result_py = if callable_path.contains('.') {
+            let (result_py, source_system) = if callable_path.contains('.') {
                 Self::invoke_class_callable(
                     self,
                     &module,
@@ -364,7 +364,7 @@ impl Bridge {
                     };
                 let kwargs =
                     Self::build_kwargs(py, &config_dict, stdin_obj.as_ref(), runtime_bindings)?;
-                Self::invoke_function_callable(
+                Self::invoke_function_callable_with_source(
                     py,
                     &module,
                     module_path,
@@ -428,6 +428,8 @@ impl Bridge {
                 } else {
                     result_unwrapped
                 };
+
+            preserve_time_series_by_name(py, source_system.as_ref(), &result_to_serialize);
 
             let (json_str, ser_elapsed) = if result_to_serialize.hasattr("to_json")? {
                 let ser_start = Instant::now();
@@ -573,7 +575,7 @@ impl Bridge {
                 .clone();
 
             let call_start = Instant::now();
-            let result_py = if callable_path.contains('.') {
+            let (result_py, source_system) = if callable_path.contains('.') {
                 Self::invoke_class_callable(
                     self,
                     &module,
@@ -663,6 +665,8 @@ impl Bridge {
                     result_unwrapped
                 };
 
+            preserve_time_series_by_name(py, source_system.as_ref(), &result_to_serialize);
+
             let write_start = Instant::now();
             let output_kind = write_artifact_result(&json, &result_to_serialize, &output_path)
                 .map_err(|error| {
@@ -697,7 +701,7 @@ impl Bridge {
         input: ClassInput<'_>,
         runtime_bindings: Option<&RuntimeBindings>,
         json: &PythonJson<'py>,
-    ) -> Result<pyo3::Bound<'py, PyAny>, BridgeError> {
+    ) -> Result<(pyo3::Bound<'py, PyAny>, Option<Py<PyAny>>), BridgeError> {
         let parts: Vec<&str> = callable_path.split('.').collect();
         if parts.len() != 2 {
             return Err(BridgeError::InvalidEntryPoint(callable_path.to_string()));
@@ -901,13 +905,14 @@ impl Bridge {
                     ));
                 }
             };
-            method.call1((stdin,)).map_err(|e| {
+            let result = method.call1((stdin,)).map_err(|e| {
                 BridgeError::Python(format_python_error(
                     method.py(),
                     e,
                     &format!("Method '{}.{}' failed", class_name, method_name),
                 ))
-            })
+            })?;
+            Ok((result, None))
         } else if signature_support.accepts_system {
             logger::step("Method has system - deserializing input to System object");
             let system_obj = match &input {
@@ -926,13 +931,15 @@ impl Bridge {
                     ));
                 }
             };
-            method.call1((system_obj,)).map_err(|e| {
+            let source_system = system_obj.unbind();
+            let result = method.call1((source_system.bind(py),)).map_err(|e| {
                 BridgeError::Python(format_python_error(
                     method.py(),
                     e,
                     &format!("Method '{}.{}' failed", class_name, method_name),
                 ))
-            })
+            })?;
+            Ok((result, Some(source_system)))
         } else {
             if input.is_present() {
                 logger::debug_lazy(|| {
@@ -942,16 +949,18 @@ impl Bridge {
                     )
                 });
             }
-            method.call0().map_err(|e| {
+            let result = method.call0().map_err(|e| {
                 BridgeError::Python(format_python_error(
                     method.py(),
                     e,
                     &format!("Method '{}.{}' failed", class_name, method_name),
                 ))
-            })
+            })?;
+            Ok((result, None))
         }
     }
 
+    #[cfg(test)]
     #[allow(clippy::too_many_arguments)]
     fn invoke_function_callable<'py>(
         py: pyo3::Python<'py>,
@@ -963,6 +972,30 @@ impl Bridge {
         kwargs: &pyo3::Bound<'py, PyDict>,
         json: &PythonJson<'py>,
     ) -> Result<pyo3::Bound<'py, PyAny>, BridgeError> {
+        Self::invoke_function_callable_with_source(
+            py,
+            module,
+            module_path,
+            callable_path,
+            stdin_json,
+            stdin_obj,
+            kwargs,
+            json,
+        )
+        .map(|(result, _)| result)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn invoke_function_callable_with_source<'py>(
+        py: pyo3::Python<'py>,
+        module: &pyo3::Bound<'py, PyModule>,
+        module_path: &str,
+        callable_path: &str,
+        stdin_json: Option<&str>,
+        stdin_obj: Option<&pyo3::Bound<'py, PyAny>>,
+        kwargs: &pyo3::Bound<'py, PyDict>,
+        json: &PythonJson<'py>,
+    ) -> Result<(pyo3::Bound<'py, PyAny>, Option<Py<PyAny>>), BridgeError> {
         logger::debug_lazy(|| format!("Function pattern: {}", callable_path));
         let func = module.getattr(callable_path).map_err(|e| {
             BridgeError::Python(format_python_error(
@@ -999,15 +1032,17 @@ impl Bridge {
             }
         }
 
+        let mut source_system = None;
         if signature_support.accepts_system {
-            logger::step("Function has stdin - deserializing to System object");
+            logger::step("Function has system - deserializing input to System object");
             let json_bytes = stdin_payload_bytes(stdin_json, stdin_obj, json)?;
 
             let system_module = PyModule::import(py, "r2x_core.system")?;
             let system_class = system_module.getattr("System")?;
             let from_json = system_class.getattr("from_json")?;
             let system_obj = from_json.call1((json_bytes.as_slice(),))?;
-            kwargs.set_item("system", system_obj)?;
+            kwargs.set_item("system", &system_obj)?;
+            source_system = Some(system_obj.unbind());
         } else if stdin_obj.is_some() {
             if signature_support.accepts_stdin {
                 logger::debug_lazy(|| {
@@ -1041,13 +1076,14 @@ impl Bridge {
                 .collect();
             format!("Final function kwargs keys: {:?}", kwarg_keys)
         });
-        func.call((), Some(kwargs)).map_err(|e| {
+        let result = func.call((), Some(kwargs)).map_err(|e| {
             BridgeError::Python(format_python_error(
                 func.py(),
                 e,
                 &format!("Function '{}' failed", callable_path),
             ))
-        })
+        })?;
+        Ok((result, source_system))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1060,7 +1096,7 @@ impl Bridge {
         kwargs: &pyo3::Bound<'py, PyDict>,
         json: &PythonJson<'py>,
         runtime_bindings: Option<&RuntimeBindings>,
-    ) -> Result<pyo3::Bound<'py, PyAny>, BridgeError> {
+    ) -> Result<(pyo3::Bound<'py, PyAny>, Option<Py<PyAny>>), BridgeError> {
         let func = module.getattr(callable_path).map_err(|error| {
             BridgeError::Python(format_python_error(
                 module.py(),
@@ -1103,22 +1139,112 @@ impl Bridge {
             kwargs.set_item("stdin", stdin)?;
         }
 
-        if signature_support.accepts_system {
+        let source_system = if signature_support.accepts_system {
             let bundle = input.ok_or_else(|| {
                 BridgeError::Python(
                     "system expected but no input artifact was provided".to_string(),
                 )
             })?;
-            kwargs.set_item("system", load_system_artifact(py, bundle)?)?;
-        }
+            let system = load_system_artifact(py, bundle)?;
+            kwargs.set_item("system", &system)?;
+            Some(system.unbind())
+        } else {
+            None
+        };
 
-        func.call((), Some(kwargs)).map_err(|error| {
+        let result = func.call((), Some(kwargs)).map_err(|error| {
             BridgeError::Python(format_python_error(
                 func.py(),
                 error,
                 &format!("Function '{}' failed", callable_path),
             ))
-        })
+        })?;
+        Ok((result, source_system))
+    }
+}
+
+/// Preserve time-series associations when a plugin builds a new System.
+///
+/// Component UUIDs are not stable across translations, so the runtime uses
+/// component names as the portable association key. Plugins remain free to
+/// perform domain-specific remapping; this fallback handles components whose
+/// names survive the translation without requiring boilerplate in every plugin.
+fn preserve_time_series_by_name(
+    py: pyo3::Python<'_>,
+    source_system: Option<&Py<PyAny>>,
+    target_system: &Bound<'_, PyAny>,
+) {
+    let Some(source_system) = source_system else {
+        return;
+    };
+    let source_system = source_system.bind(py);
+
+    let Ok(source_components) = source_system.call_method0("iter_all_components") else {
+        return;
+    };
+    let Ok(target_components) = target_system.call_method0("iter_all_components") else {
+        return;
+    };
+    let Ok(target_components) = target_components.try_iter() else {
+        return;
+    };
+
+    let mut target_by_name = HashMap::new();
+    for component in target_components {
+        let Ok(component) = component else {
+            continue;
+        };
+        let Ok(name) = component
+            .getattr("name")
+            .and_then(|value| value.extract::<String>())
+        else {
+            continue;
+        };
+        target_by_name.insert(name, component.unbind());
+    }
+
+    let Ok(source_components) = source_components.try_iter() else {
+        return;
+    };
+    let mut copied = 0;
+    for source_component in source_components {
+        let Ok(source_component) = source_component else {
+            continue;
+        };
+        let Ok(name) = source_component
+            .getattr("name")
+            .and_then(|value| value.extract::<String>())
+        else {
+            continue;
+        };
+        let Some(target_component) = target_by_name.get(&name) else {
+            continue;
+        };
+        let Ok(time_series) = source_system.call_method1("list_time_series", (&source_component,))
+        else {
+            continue;
+        };
+        let Ok(time_series) = time_series.try_iter() else {
+            continue;
+        };
+        for series in time_series {
+            let Ok(series) = series else {
+                continue;
+            };
+            if target_system
+                .call_method1("add_time_series", (&series, target_component.bind(py)))
+                .is_ok()
+            {
+                copied += 1;
+            }
+        }
+    }
+
+    if copied > 0 {
+        logger::debug(&format!(
+            "Preserved {} time-series associations by component name",
+            copied
+        ));
     }
 }
 
@@ -1474,8 +1600,9 @@ fn discover_and_instantiate_config<'py>(
 mod tests {
     use super::{
         has_cached_method_signature, method_accepts_stdin_cached, method_stdin_support,
-        remove_cached_method_signature, should_parse_stdin_for_exporter_context,
-        should_parse_stdin_for_function_kwargs, stdin_payload_bytes, PythonJson,
+        preserve_time_series_by_name, remove_cached_method_signature,
+        should_parse_stdin_for_exporter_context, should_parse_stdin_for_function_kwargs,
+        stdin_payload_bytes, PythonJson,
     };
     use crate::plugin_invoker::{ArtifactBundle, ArtifactOutputKind};
     use crate::python_bridge::Bridge;
@@ -1484,6 +1611,59 @@ mod tests {
     use r2x_manifest::types::Parameter;
     use std::ffi::CString;
     use tempfile::tempdir;
+
+    #[test]
+    fn preserves_time_series_for_matching_component_names() -> Result<(), String> {
+        pyo3::Python::initialize();
+        pyo3::Python::attach(|py| -> Result<(), String> {
+            let module = install_module(
+                py,
+                "time_series_transfer_test",
+                r#"
+class Component:
+    def __init__(self, name):
+        self.name = name
+        self.time_series = []
+
+class System:
+    def __init__(self, components):
+        self.components = components
+
+    def iter_all_components(self):
+        return iter(self.components)
+
+    def list_time_series(self, component):
+        return component.time_series
+
+    def add_time_series(self, series, component):
+        component.time_series.append(series)
+"#,
+            )?;
+            let component = module.getattr("Component").map_err(|e| e.to_string())?;
+            let system = module.getattr("System").map_err(|e| e.to_string())?;
+            let source_component = component.call1(("bus-1",)).map_err(|e| e.to_string())?;
+            source_component
+                .setattr("time_series", vec!["load-profile"])
+                .map_err(|e| e.to_string())?;
+            let target_component = component.call1(("bus-1",)).map_err(|e| e.to_string())?;
+            let source = system
+                .call1((vec![source_component],))
+                .map_err(|e| e.to_string())?;
+            let target = system
+                .call1((vec![target_component.clone()],))
+                .map_err(|e| e.to_string())?;
+            let source_owned = source.unbind();
+
+            preserve_time_series_by_name(py, Some(&source_owned), &target);
+
+            let copied = target_component
+                .getattr("time_series")
+                .and_then(|value| value.extract::<Vec<String>>())
+                .map_err(|e| e.to_string())?;
+            assert_eq!(copied, vec!["load-profile"]);
+            Ok(())
+        })
+    }
 
     fn install_module<'py>(
         py: pyo3::Python<'py>,

--- a/crates/r2x-python/src/plugin_regular.rs
+++ b/crates/r2x-python/src/plugin_regular.rs
@@ -1166,9 +1166,10 @@ impl Bridge {
 /// Preserve time-series associations when a plugin builds a new System.
 ///
 /// Component UUIDs are not stable across translations, so the runtime uses
-/// component names as the portable association key. Plugins remain free to
-/// perform domain-specific remapping; this fallback handles components whose
-/// names survive the translation without requiring boilerplate in every plugin.
+/// owner names as the portable association key. Plugins remain free to perform
+/// domain-specific remapping; this fallback handles components and supplemental
+/// attributes whose names survive the translation without boilerplate in every
+/// plugin.
 fn preserve_time_series_by_name(
     py: pyo3::Python<'_>,
     source_system: Option<&Py<PyAny>>,
@@ -1178,49 +1179,71 @@ fn preserve_time_series_by_name(
         return;
     };
     let source_system = source_system.bind(py);
+    let copied =
+        copy_time_series_for_named_owners(py, source_system, target_system, "iter_all_components")
+            + copy_time_series_for_named_owners(
+                py,
+                source_system,
+                target_system,
+                "get_supplemental_attributes",
+            );
 
-    let Ok(source_components) = source_system.call_method0("iter_all_components") else {
-        return;
+    if copied > 0 {
+        logger::debug(&format!(
+            "Preserved {} time-series associations by owner name",
+            copied
+        ));
+    }
+}
+
+fn copy_time_series_for_named_owners(
+    py: pyo3::Python<'_>,
+    source_system: &Bound<'_, PyAny>,
+    target_system: &Bound<'_, PyAny>,
+    owner_method: &str,
+) -> usize {
+    let Ok(source_owners) = source_system.call_method0(owner_method) else {
+        return 0;
     };
-    let Ok(target_components) = target_system.call_method0("iter_all_components") else {
-        return;
+    let Ok(target_owners) = target_system.call_method0(owner_method) else {
+        return 0;
     };
-    let Ok(target_components) = target_components.try_iter() else {
-        return;
+    let Ok(target_owners) = target_owners.try_iter() else {
+        return 0;
     };
 
     let mut target_by_name = HashMap::new();
-    for component in target_components {
-        let Ok(component) = component else {
+    for owner in target_owners {
+        let Ok(owner) = owner else {
             continue;
         };
-        let Ok(name) = component
+        let Ok(name) = owner
             .getattr("name")
             .and_then(|value| value.extract::<String>())
         else {
             continue;
         };
-        target_by_name.insert(name, component.unbind());
+        target_by_name.insert(name, owner.unbind());
     }
 
-    let Ok(source_components) = source_components.try_iter() else {
-        return;
+    let Ok(source_owners) = source_owners.try_iter() else {
+        return 0;
     };
     let mut copied = 0;
-    for source_component in source_components {
-        let Ok(source_component) = source_component else {
+    for source_owner in source_owners {
+        let Ok(source_owner) = source_owner else {
             continue;
         };
-        let Ok(name) = source_component
+        let Ok(name) = source_owner
             .getattr("name")
             .and_then(|value| value.extract::<String>())
         else {
             continue;
         };
-        let Some(target_component) = target_by_name.get(&name) else {
+        let Some(target_owner) = target_by_name.get(&name) else {
             continue;
         };
-        let Ok(time_series) = source_system.call_method1("list_time_series", (&source_component,))
+        let Ok(time_series) = source_system.call_method1("list_time_series", (&source_owner,))
         else {
             continue;
         };
@@ -1232,20 +1255,14 @@ fn preserve_time_series_by_name(
                 continue;
             };
             if target_system
-                .call_method1("add_time_series", (&series, target_component.bind(py)))
+                .call_method1("add_time_series", (&series, target_owner.bind(py)))
                 .is_ok()
             {
                 copied += 1;
             }
         }
     }
-
-    if copied > 0 {
-        logger::debug(&format!(
-            "Preserved {} time-series associations by component name",
-            copied
-        ));
-    }
+    copied
 }
 
 fn write_artifact_result<'py>(
@@ -1626,17 +1643,21 @@ class Component:
         self.time_series = []
 
 class System:
-    def __init__(self, components):
+    def __init__(self, components, supplemental_attributes):
         self.components = components
+        self.supplemental_attributes = supplemental_attributes
 
     def iter_all_components(self):
         return iter(self.components)
 
-    def list_time_series(self, component):
-        return component.time_series
+    def get_supplemental_attributes(self):
+        return iter(self.supplemental_attributes)
 
-    def add_time_series(self, series, component):
-        component.time_series.append(series)
+    def list_time_series(self, owner):
+        return owner.time_series
+
+    def add_time_series(self, series, owner):
+        owner.time_series.append(series)
 "#,
             )?;
             let component = module.getattr("Component").map_err(|e| e.to_string())?;
@@ -1646,11 +1667,19 @@ class System:
                 .setattr("time_series", vec!["load-profile"])
                 .map_err(|e| e.to_string())?;
             let target_component = component.call1(("bus-1",)).map_err(|e| e.to_string())?;
+            let source_attribute = component.call1(("geo-1",)).map_err(|e| e.to_string())?;
+            source_attribute
+                .setattr("time_series", vec!["weather-profile"])
+                .map_err(|e| e.to_string())?;
+            let target_attribute = component.call1(("geo-1",)).map_err(|e| e.to_string())?;
             let source = system
-                .call1((vec![source_component],))
+                .call1((vec![source_component], vec![source_attribute]))
                 .map_err(|e| e.to_string())?;
             let target = system
-                .call1((vec![target_component.clone()],))
+                .call1((
+                    vec![target_component.clone()],
+                    vec![target_attribute.clone()],
+                ))
                 .map_err(|e| e.to_string())?;
             let source_owned = source.unbind();
 
@@ -1661,6 +1690,11 @@ class System:
                 .and_then(|value| value.extract::<Vec<String>>())
                 .map_err(|e| e.to_string())?;
             assert_eq!(copied, vec!["load-profile"]);
+            let copied_attribute = target_attribute
+                .getattr("time_series")
+                .and_then(|value| value.extract::<Vec<String>>())
+                .map_err(|e| e.to_string())?;
+            assert_eq!(copied_attribute, vec!["weather-profile"]);
             Ok(())
         })
     }


### PR DESCRIPTION
## Summary
- preserve referenced time-series sidecars when inline pipeline JSON is persisted
- preserve time-series associations when a plugin creates a translated System, matching components and supplemental attributes by name
- rewrite sidecar references to portable paths next to the persisted JSON
- add regression coverage for relative sidecars and translated associations

## Testing
- `cargo test --workspace`
- `cargo fmt --all -- --check`