### PR TITLE
feat(cli): support Unix plugin streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,35 +148,47 @@ r2x run pipeline.yaml my-pipeline --output output.zip --zip
 
 ### Running Plugins Directly
 
-Skip the pipeline and run a single plugin with inline arguments.
-
-Use `--output <FILE>` when you want a portable JSON artifact, especially on Windows. Shell redirection in PowerShell can produce UTF-16 files, while `r2x run plugin ... --output <FILE>` writes the JSON bytes directly.
+Skip the pipeline and run a single plugin with inline arguments. The short form is `r2x run <plugin-ref>`; `r2x run plugin <plugin-ref>` remains supported.
 
 ```bash
 # Run a plugin directly with idiomatic flags
-r2x run plugin r2x-reeds.reeds-parser \
+r2x run r2x-reeds.reeds-parser \
   --path /path/to/reeds/run \
   --solve-year 2030 \
   --weather-year 2012
 
 # Existing key=value arguments also work
-r2x run plugin r2x-reeds.reeds-parser \
+r2x run r2x-reeds.reeds-parser \
   path=/path/to/reeds/run \
   solve_year=2030 \
   weather_year=2012
 
+# Pipe a System through compatible plugins in one shell job
+set -o pipefail
+r2x run r2x-reeds.reeds-parser \
+  --path /path/to/reeds/run \
+  --solve-year 2030 \
+  --weather-year 2012 |
+r2x run r2x-reeds.add-pcm-defaults \
+  --pcm-defaults-fpath config/pcm_defaults.json
+
+# Write a durable System JSON entrypoint and its adjacent sidecar directory
+r2x run r2x-reeds.reeds-parser \
+  --path /path/to/reeds/run \
+  --solve-year 2030 \
+  --weather-year 2012 \
+  -o artifacts/system.json
+
+# Read the durable System by path; relative sidecars resolve beside the JSON file
+r2x run r2x-reeds.add-pcm-defaults \
+  -i artifacts/system.json \
+  --pcm-defaults-fpath config/pcm_defaults.json
+
 # Show a plugin's help
 r2x run plugin r2x-reeds.reeds-parser --show-help
 
-# Write portable UTF-8 JSON directly to a file
-r2x run plugin r2x-reeds.reeds-parser \
-  --output plugin-output.json \
-  --path /path/to/reeds/run \
-  --solve-year 2030 \
-  --weather-year 2012
-
 # Run repeated invocations and print timing summary
-r2x run plugin r2x-reeds.reeds-parser --repeat 10 --benchmark solve_year=2030
+r2x run r2x-reeds.reeds-parser --repeat 10 --benchmark solve_year=2030
 
 # Compare two benchmark outputs (baseline vs current)
 python3 scripts/compare_benchmark_summary.py --baseline baseline.txt --current current.txt
@@ -199,6 +211,15 @@ export R2X_BENCHMARK_REGRESSION_PCT=15
 # List all runnable plugins
 r2x run plugin
 ```
+
+Without `-o`, System JSON on stdout embeds an absolute r2x sidecar location,
+so it is safe to pass to the next command in the same shell job. With `-o`,
+r2x creates parent directories, replaces the JSON entrypoint, and writes a
+portable sibling `<stem>_time_series/` directory; read that artifact with `-i`,
+not shell redirection. Plugin diagnostics use stderr, and exporters write their
+configured files without emitting a JSON record.
+
+For Torc parameterization, file dependencies, and the distinction between live pipes and durable `-o` / `-i` boundaries, see [Use r2x plugin streams in Torc](docs/torc-plugin-streams.md).
 
 ### Pipeline File Format
 

--- a/crates/r2x-cli/src/commands/run/mod.rs
+++ b/crates/r2x-cli/src/commands/run/mod.rs
@@ -1,6 +1,7 @@
 use crate::common::GlobalOpts;
 use crate::errors::PipelineError;
 use crate::help;
+use crate::manifest_lookup::resolve_plugin_ref;
 use clap::Parser;
 use pipeline::{handle_pipeline_mode, PipelineModeOptions};
 use plugin::handle_plugin_command;
@@ -8,10 +9,11 @@ use r2x_artifacts::ArtifactError;
 use r2x_logger as logger;
 use r2x_manifest::errors::ManifestError;
 use r2x_manifest::runtime::{PluginRole, RuntimeBindings};
-use r2x_manifest::types::PluginType;
+use r2x_manifest::types::{Manifest, PluginType};
 use r2x_python::errors::BridgeError;
 use r2x_python::plugin_invoker::PluginInvocationTimings;
 use std::num::NonZeroUsize;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 mod pipeline;
@@ -75,9 +77,22 @@ impl From<PipelineError> for RunError {
 }
 
 #[derive(Parser, Debug)]
+#[command(
+    after_help = "Modes:\n  r2x run <plugin-ref> [PLUGIN_OPTIONS...]\n  r2x run <pipeline.yaml> <pipeline-name> [--list|--print|--dry-run]\n\nUse `r2x run plugin <plugin-ref>` to force legacy direct-plugin mode when a pipeline name and plugin name conflict."
+)]
 pub struct RunCommand {
     #[command(subcommand)]
     command: Option<RunSubcommand>,
+    #[arg(
+        value_name = "TARGET",
+        trailing_var_arg = true,
+        allow_hyphen_values = true
+    )]
+    args: Vec<String>,
+}
+
+#[derive(Parser, Debug)]
+struct PipelineCommand {
     #[arg(value_name = "YAML_PATH")]
     yaml_path: Option<String>,
     #[arg(value_name = "NAME")]
@@ -106,11 +121,19 @@ pub struct PluginCommand {
     #[arg(long)]
     show_help: bool,
     #[arg(
+        short = 'i',
         long,
         value_name = "FILE",
-        help = "Write plugin JSON output to a UTF-8 file instead of stdout"
+        help = "Read plugin JSON input from FILE instead of stdin"
     )]
-    output: Option<String>,
+    input: Option<PathBuf>,
+    #[arg(
+        short = 'o',
+        long,
+        value_name = "FILE",
+        help = "Write plugin output to FILE instead of stdout"
+    )]
+    output: Option<PathBuf>,
     #[arg(
         long,
         value_name = "N",
@@ -131,29 +154,78 @@ pub fn handle_run(cmd: RunCommand, opts: GlobalOpts) -> Result<(), RunError> {
     match cmd.command {
         Some(RunSubcommand::Plugin(plugin_cmd)) => handle_plugin_command(plugin_cmd, &opts),
         None => {
-            // No pipeline name and no flags → show friendly help
-            if cmd.pipeline_name.is_none() && !cmd.list && !cmd.print && !cmd.dry_run {
-                if let Err(e) = help::show_run_help() {
-                    logger::error(&e);
+            if cmd.args.is_empty() {
+                if let Err(error) = help::show_run_help() {
+                    logger::error(&error);
                     std::process::exit(1);
                 }
                 return Ok(());
             }
-            let yaml_path = cmd.yaml_path.unwrap_or_else(|| "pipeline.yaml".to_string());
-            handle_pipeline_mode(
-                yaml_path,
-                cmd.pipeline_name,
-                PipelineModeOptions {
-                    list: cmd.list,
-                    print: cmd.print,
-                    dry_run: cmd.dry_run,
-                    output: cmd.output,
-                    zip_output: cmd.zip,
-                },
-                &opts,
-            )
+            if is_direct_plugin_target(&cmd.args) {
+                let plugin_cmd = parse_direct_plugin_command(&cmd.args)?;
+                handle_plugin_command(plugin_cmd, &opts)
+            } else {
+                handle_pipeline_command(&cmd.args, &opts)
+            }
         }
     }
+}
+
+fn is_direct_plugin_target(args: &[String]) -> bool {
+    let Some(target) = args.first() else {
+        return false;
+    };
+    if target.starts_with('-') || is_pipeline_path(target) {
+        return false;
+    }
+    if target.contains('.') {
+        return true;
+    }
+
+    let Ok(manifest) = Manifest::load() else {
+        return false;
+    };
+    resolve_plugin_ref(&manifest, target).is_ok()
+}
+
+fn is_pipeline_path(target: &str) -> bool {
+    let path = Path::new(target);
+    path.exists()
+        || matches!(
+            path.extension().and_then(|extension| extension.to_str()),
+            Some("yaml" | "yml")
+        )
+}
+
+fn parse_direct_plugin_command(args: &[String]) -> Result<PluginCommand, RunError> {
+    let mut argv = Vec::with_capacity(args.len() + 1);
+    argv.push("r2x run".to_string());
+    argv.extend(args.iter().cloned());
+    PluginCommand::try_parse_from(argv).map_err(|error| RunError::InvalidArgs(error.to_string()))
+}
+
+fn handle_pipeline_command(args: &[String], opts: &GlobalOpts) -> Result<(), RunError> {
+    let mut argv = Vec::with_capacity(args.len() + 1);
+    argv.push("r2x run".to_string());
+    argv.extend(args.iter().cloned());
+    let pipeline_cmd = PipelineCommand::try_parse_from(argv)
+        .map_err(|error| RunError::InvalidArgs(error.to_string()))?;
+
+    let yaml_path = pipeline_cmd
+        .yaml_path
+        .unwrap_or_else(|| "pipeline.yaml".to_string());
+    handle_pipeline_mode(
+        yaml_path,
+        pipeline_cmd.pipeline_name,
+        PipelineModeOptions {
+            list: pipeline_cmd.list,
+            print: pipeline_cmd.print,
+            dry_run: pipeline_cmd.dry_run,
+            output: pipeline_cmd.output,
+            zip_output: pipeline_cmd.zip,
+        },
+        opts,
+    )
 }
 
 pub(super) fn build_call_target(bindings: &RuntimeBindings) -> Result<String, RunError> {

--- a/crates/r2x-cli/src/commands/run/pipeline/mod.rs
+++ b/crates/r2x-cli/src/commands/run/pipeline/mod.rs
@@ -10,8 +10,8 @@ use r2x_logger as logger;
 use r2x_manifest::runtime::build_runtime_bindings;
 use r2x_manifest::types::Manifest;
 use r2x_python::plugin_invoker::{
-    ArtifactBundle, ArtifactOutputKind, PluginArtifactInvocationResult, PluginInvocationResult,
-    PluginInvocationTimings,
+    ArtifactBundle, ArtifactOutputKind, PluginArtifactInvocationResult, PluginInvocationOutput,
+    PluginInvocationResult, PluginInvocationTimings,
 };
 use r2x_python::python_bridge::Bridge;
 use std::path::Path;
@@ -370,26 +370,30 @@ fn execute_pipeline(
         let no_stdout = opts.no_stdout || logger::get_no_stdout();
         match (invocation_result, upgraded_artifact) {
             (PipelineInvocation::Inline(result), Some(artifact)) => {
-                if !result.output.is_empty() && result.output != "null" {
-                    std::fs::write(artifact.entrypoint_path(), result.output.as_bytes())
-                        .map_err(PipelineError::Io)?;
+                if let PluginInvocationOutput::Json(output) = result.output {
+                    if !output.is_empty() && output != "null" {
+                        std::fs::write(artifact.entrypoint_path(), output.as_bytes())
+                            .map_err(PipelineError::Io)?;
+                    }
                 }
                 logger::debug("Upgrader preserved the current artifact bundle");
                 current_payload = Some(PipelinePayload::Artifact(artifact));
             }
-            (PipelineInvocation::Inline(result), None)
-                if !result.output.is_empty() && result.output != "null" =>
-            {
-                if no_stdout {
-                    logger::debug("Plugin produced output (suppressed by --no-stdout)");
-                } else {
-                    logger::debug(&format!(
-                        "Plugin produced output ({} bytes)",
-                        result.output.len()
-                    ));
+            (PipelineInvocation::Inline(result), None) => match result.output {
+                PluginInvocationOutput::Json(output) if !output.is_empty() && output != "null" => {
+                    if no_stdout {
+                        logger::debug("Plugin produced output (suppressed by --no-stdout)");
+                    } else {
+                        logger::debug(&format!("Plugin produced output ({} bytes)", output.len()));
+                    }
+                    current_payload = Some(PipelinePayload::Inline(output));
                 }
-                current_payload = Some(PipelinePayload::Inline(result.output));
-            }
+                PluginInvocationOutput::Json(_)
+                | PluginInvocationOutput::Persisted
+                | PluginInvocationOutput::Empty => {
+                    logger::debug("Plugin produced no output or output not used");
+                }
+            },
             (PipelineInvocation::Artifact(result), _)
                 if result.output_kind != ArtifactOutputKind::Empty =>
             {
@@ -400,7 +404,7 @@ fn execute_pipeline(
                 ));
                 current_payload = Some(PipelinePayload::Artifact(output_artifact));
             }
-            (PipelineInvocation::Inline(_), None) | (PipelineInvocation::Artifact(_), _) => {
+            (PipelineInvocation::Artifact(_), _) => {
                 logger::debug("Plugin produced no output or output not used");
             }
         }

--- a/crates/r2x-cli/src/commands/run/plugin.rs
+++ b/crates/r2x-cli/src/commands/run/plugin.rs
@@ -8,9 +8,11 @@ use r2x_logger as logger;
 use r2x_manifest::runtime::build_runtime_bindings;
 use r2x_manifest::types::Manifest;
 use r2x_manifest::types::Plugin;
-use r2x_python::plugin_invoker::PluginInvocationResult;
+use r2x_python::plugin_invoker::{PluginInput, PluginInvocationOutput, PluginInvocationResult};
 use r2x_python::python_bridge::Bridge;
 use std::collections::BTreeSet;
+use std::io::{self, IsTerminal, Read};
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 pub(super) fn handle_plugin_command(cmd: PluginCommand, opts: &GlobalOpts) -> Result<(), RunError> {
@@ -24,6 +26,7 @@ pub(super) fn handle_plugin_command(cmd: PluginCommand, opts: &GlobalOpts) -> Re
                     &plugin_name,
                     &cmd.args,
                     opts,
+                    cmd.input,
                     cmd.output,
                     cmd.repeat.get(),
                     cmd.benchmark,
@@ -43,7 +46,7 @@ fn list_available_plugins() -> Result<(), RunError> {
         "  Use {} to list installed plugins, then:",
         "r2x list".bold()
     );
-    println!("  r2x run plugin <plugin-name> [args...]");
+    println!("  r2x run <plugin-name> [args...]");
     println!("  r2x run plugin <plugin-name> --show-help");
     println!();
     Ok(())
@@ -53,7 +56,8 @@ fn run_plugin(
     plugin_name: &str,
     args: &[String],
     opts: &GlobalOpts,
-    output_file: Option<String>,
+    input_file: Option<PathBuf>,
+    output_file: Option<PathBuf>,
     repeat: usize,
     benchmark: bool,
 ) -> Result<(), RunError> {
@@ -87,6 +91,7 @@ fn run_plugin(
     let runtime_bindings = build_runtime_bindings(plugin);
     let target = build_call_target(&runtime_bindings)?;
 
+    let input = read_plugin_input(input_file.as_deref())?;
     let bridge = Bridge::get()?;
     logger::debug(&format!("Invoking plugin with target: {}", target));
 
@@ -94,13 +99,25 @@ fn run_plugin(
     let mut total_python_invocation = Duration::ZERO;
     let mut total_serialization = Duration::ZERO;
     let mut timing_samples: usize = 0;
-    let mut result = String::new();
+    let mut result = PluginInvocationOutput::Empty;
     let mut timings = None;
 
     for iteration in 0..repeat {
         logger::set_current_plugin(Some(plugin_name.to_string()));
         let start = Instant::now();
-        let invocation_result = bridge.invoke_plugin(&target, &config_json, None, Some(plugin));
+        let invocation_input = input.as_ref().map(PluginInputSource::as_bridge_input);
+        let invocation_output = if iteration + 1 == repeat {
+            output_file.as_deref()
+        } else {
+            None
+        };
+        let invocation_result = bridge.invoke_plugin_direct(
+            &target,
+            &config_json,
+            invocation_input,
+            invocation_output,
+            Some(plugin),
+        );
         let elapsed = start.elapsed();
         total_elapsed += elapsed;
         // Clear plugin context after each execution attempt
@@ -132,17 +149,38 @@ fn run_plugin(
 
     let no_stdout = opts.no_stdout || logger::get_no_stdout();
     if let Some(output_path) = output_file {
-        if !result.is_empty() {
-            logger::step(&format!("Writing plugin output to: {}", output_path));
-            std::fs::write(&output_path, result.as_bytes())
-                .map_err(|e| RunError::Pipeline(crate::errors::PipelineError::Io(e)))?;
-            logger::success(&format!("Plugin output saved to: {}", output_path));
+        match result {
+            PluginInvocationOutput::Persisted => {
+                logger::success(&format!(
+                    "Plugin output saved to: {}",
+                    output_path.display()
+                ));
+            }
+            PluginInvocationOutput::Json(output) => {
+                logger::step(&format!(
+                    "Writing plugin output to: {}",
+                    output_path.display()
+                ));
+                write_json_output(&output_path, &output)?;
+                logger::success(&format!(
+                    "Plugin output saved to: {}",
+                    output_path.display()
+                ));
+            }
+            PluginInvocationOutput::Empty => {
+                return Err(RunError::InvalidArgs(format!(
+                    "plugin '{}' produced no JSON output; use its plugin-specific output option instead",
+                    plugin_name
+                )));
+            }
         }
-    } else if !result.is_empty() && result != "null" {
-        if opts.suppress_stdout() || no_stdout {
-            logger::debug("Plugin output suppressed");
-        } else {
-            println!("{}", result);
+    } else if let PluginInvocationOutput::Json(output) = result {
+        if !output.is_empty() && output != "null" {
+            if opts.suppress_stdout() || no_stdout {
+                logger::debug("Plugin output suppressed");
+            } else {
+                println!("{}", output);
+            }
         }
     }
 
@@ -189,6 +227,69 @@ fn run_plugin(
     }
 
     Ok(())
+}
+
+enum PluginInputSource {
+    Stdin(String),
+    File(PathBuf),
+}
+
+impl PluginInputSource {
+    fn as_bridge_input(&self) -> PluginInput<'_> {
+        match self {
+            Self::Stdin(payload) => PluginInput::Json(payload),
+            Self::File(path) => PluginInput::File(path),
+        }
+    }
+}
+
+fn write_json_output(output_path: &Path, output: &str) -> Result<(), RunError> {
+    if let Some(parent) = output_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| RunError::Pipeline(crate::errors::PipelineError::Io(error)))?;
+    }
+    std::fs::write(output_path, output.as_bytes())
+        .map_err(|error| RunError::Pipeline(crate::errors::PipelineError::Io(error)))
+}
+
+fn read_plugin_input(input_file: Option<&Path>) -> Result<Option<PluginInputSource>, RunError> {
+    if input_file.is_some_and(|path| path == Path::new("-")) {
+        return read_piped_stdin().map(|input| input.map(PluginInputSource::Stdin));
+    }
+
+    let stdin = read_piped_stdin()?;
+    if let (Some(_), Some(_)) = (input_file, stdin.as_ref()) {
+        return Err(RunError::InvalidArgs(
+            "--input FILE cannot be combined with JSON supplied on stdin".to_string(),
+        ));
+    }
+
+    if let Some(path) = input_file {
+        return Ok(Some(PluginInputSource::File(path.to_path_buf())));
+    }
+
+    Ok(stdin.map(PluginInputSource::Stdin))
+}
+
+fn read_piped_stdin() -> Result<Option<String>, RunError> {
+    let mut stdin = io::stdin();
+    if stdin.is_terminal() {
+        return Ok(None);
+    }
+
+    let mut input = String::new();
+    stdin.read_to_string(&mut input).map_err(|error| {
+        RunError::Config(format!("Failed to read plugin input from stdin: {error}"))
+    })?;
+
+    if input.trim().is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(input))
+    }
 }
 
 #[derive(Debug)]
@@ -299,7 +400,7 @@ impl PluginArgumentSpec {
     }
 
     fn example_command(&self) -> String {
-        let mut command = format!("r2x run plugin {}", self.plugin_name);
+        let mut command = format!("r2x run {}", self.plugin_name);
         if self.required_keys.is_empty() {
             if let Some(key) = self.known_keys.iter().next() {
                 command.push_str(&format!(" --{} <value>", cli_flag_name(key)));

--- a/crates/r2x-cli/src/help.rs
+++ b/crates/r2x-cli/src/help.rs
@@ -39,11 +39,12 @@ pub(crate) fn show_run_help() -> Result<(), String> {
     println!("    r2x run <pipeline.yaml> [pipeline-name]");
     println!();
     println!("  Run a plugin directly:");
-    println!("    r2x run plugin <plugin-name> [OPTIONS]");
-    println!("      (use --output <FILE> for portable UTF-8 JSON files; use -q for quiet logs, -q -q to suppress plugin stdout)");
+    println!("    r2x run <plugin-name> [OPTIONS]");
+    println!("      (use -i/--input for a durable System, -o/--output to persist one)");
+    println!("      (use `r2x run plugin <plugin-name>` for the legacy explicit form)");
     println!();
     println!("  Get plugin help:");
-    println!("    r2x run plugin <plugin-name> --show-help");
+    println!("    r2x run <plugin-name> --show-help");
     println!();
     println!("  List pipelines in YAML:");
     println!("    r2x run <pipeline.yaml> --list");
@@ -106,8 +107,8 @@ pub(crate) fn show_plugin_help(plugin_name: &str) -> Result<(), String> {
     };
 
     println!("\nUsage:");
-    println!("  r2x run plugin {}{}", plugin_name, usage_options);
-    println!("    (add --output <FILE> for UTF-8 JSON files, or -q to silence logs, -q -q to hide stdout)");
+    println!("  r2x run {}{}", plugin_name, usage_options);
+    println!("    (add -i <FILE> to load a System or -o <FILE> to persist one)");
 
     // Show parameters
     if !plugin.parameters.is_empty() {
@@ -170,8 +171,8 @@ pub(crate) fn show_plugin_help(plugin_name: &str) -> Result<(), String> {
     println!("  --set key=value is accepted as an explicit key/value form.");
 
     println!("\nExamples:");
-    println!("  r2x run plugin {} --show-help", plugin_name);
-    println!("  r2x run plugin {}{}", plugin_name, example_options);
+    println!("  r2x run {} --show-help", plugin_name);
+    println!("  r2x run {}{}", plugin_name, example_options);
 
     Ok(())
 }

--- a/crates/r2x-cli/src/main.rs
+++ b/crates/r2x-cli/src/main.rs
@@ -10,6 +10,7 @@ use r2x::common::GlobalOpts;
 use r2x_config as config_manager;
 use r2x_logger as logger;
 use r2x_python::python_bridge::process_exit;
+use std::ffi::OsString;
 
 #[derive(Parser)]
 #[command(name = "r2x")]
@@ -121,6 +122,64 @@ enum Commands {
     Self_(self_update::SelfNamespace),
 }
 
+/// Move root global flags ahead of `run` before Clap parses its trailing target.
+///
+/// `RunCommand` captures the target and all following values verbatim so it
+/// can distinguish a pipeline path from a plugin reference. Without this
+/// normalization, root-global flags written after `run` would be mistaken for
+/// plugin or pipeline arguments and would miss logger initialization.
+fn normalize_run_global_args(args: Vec<OsString>) -> Vec<OsString> {
+    let Some(command_index) = args.iter().enumerate().skip(1).find_map(|(index, arg)| {
+        let arg = arg.to_string_lossy();
+        (!is_global_run_option(&arg) && arg != "--").then_some(index)
+    }) else {
+        return args;
+    };
+
+    if args[command_index].to_string_lossy() != "run" {
+        return args;
+    }
+
+    let mut normalized = Vec::with_capacity(args.len());
+    normalized.extend(args[..command_index].iter().cloned());
+
+    let mut run_args = Vec::new();
+    let mut moved_globals = Vec::new();
+    let mut parse_options = true;
+    for arg in args[command_index + 1..].iter().cloned() {
+        let arg_text = arg.to_string_lossy();
+        if parse_options && arg_text == "--" {
+            parse_options = false;
+            run_args.push(arg);
+        } else if parse_options && is_global_run_option(&arg_text) {
+            moved_globals.push(arg);
+        } else {
+            run_args.push(arg);
+        }
+    }
+
+    normalized.extend(moved_globals);
+    normalized.push(OsString::from("run"));
+    normalized.extend(run_args);
+    normalized
+}
+
+fn is_global_run_option(arg: &str) -> bool {
+    matches!(
+        arg,
+        "--quiet" | "--verbose" | "--log-python" | "--python-log" | "--no-stdout"
+    ) || is_global_short_flag(arg)
+}
+
+fn is_global_short_flag(arg: &str) -> bool {
+    arg.starts_with('-')
+        && !arg.starts_with("--")
+        && arg.len() > 1
+        && arg[1..]
+            .chars()
+            .all(|character| matches!(character, 'q' | 'v'))
+}
+
 fn with_plugin_context<F>(action: F) -> Result<(), r2x::plugins::error::PluginError>
 where
     F: FnOnce(&mut plugins::context::PluginContext) -> Result<(), r2x::plugins::error::PluginError>,
@@ -144,7 +203,7 @@ fn main() {
         colored::control::set_override(false);
     }
 
-    let cli = Cli::parse();
+    let cli = Cli::parse_from(normalize_run_global_args(std::env::args_os().collect()));
 
     let mut startup_config = match config_manager::Config::load() {
         Ok(cfg) => Some(cfg),
@@ -285,5 +344,57 @@ fn main() {
                 std::process::exit(1);
             }
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_run_global_args;
+    use std::ffi::OsString;
+
+    fn args(values: &[&str]) -> Vec<OsString> {
+        values.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn moves_global_options_before_run_for_clap() {
+        assert_eq!(
+            normalize_run_global_args(args(&[
+                "r2x",
+                "run",
+                "r2x-reeds.reeds-parser",
+                "-qv",
+                "--python-log",
+                "--no-stdout",
+            ])),
+            args(&[
+                "r2x",
+                "-qv",
+                "--python-log",
+                "--no-stdout",
+                "run",
+                "r2x-reeds.reeds-parser",
+            ])
+        );
+    }
+
+    #[test]
+    fn keeps_options_after_double_dash_with_the_plugin() {
+        assert_eq!(
+            normalize_run_global_args(args(&[
+                "r2x",
+                "run",
+                "r2x-reeds.reeds-parser",
+                "--",
+                "--quiet",
+            ])),
+            args(&["r2x", "run", "r2x-reeds.reeds-parser", "--", "--quiet",])
+        );
+    }
+
+    #[test]
+    fn leaves_non_run_commands_unchanged() {
+        let input = args(&["r2x", "install", "--no-stdout", "r2x-reeds"]);
+        assert_eq!(normalize_run_global_args(input.clone()), input);
     }
 }

--- a/crates/r2x-cli/tests/integration.rs
+++ b/crates/r2x-cli/tests/integration.rs
@@ -178,6 +178,7 @@ fn test_plugins_help() {
             "Usage: {} run plugin",
             EXECUTABLE_NAME
         )))
+        .stdout(predicate::str::contains("--input <FILE>"))
         .stdout(predicate::str::contains("--output <FILE>"))
         .stdout(predicate::str::contains("--repeat"))
         .stdout(predicate::str::contains("--benchmark"));
@@ -220,6 +221,288 @@ fn test_direct_plugin_output_writes_utf8_json_and_read_accepts_it(
         ])
         .assert()
         .success();
+
+    Ok(())
+}
+
+#[test]
+fn test_direct_plugin_receives_system_from_stdin() -> Result<(), Box<dyn std::error::Error>> {
+    let Ok(env) = PipelineHarness::new() else {
+        return Ok(());
+    };
+
+    env.command()
+        .args(["run", "r2x_reeds.with_system_function"])
+        .write_stdin(r#"{"system":"reeds","status":"input"}"#)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "\"status\": \"function-with-system\"",
+        ));
+
+    Ok(())
+}
+
+#[test]
+fn test_direct_plugin_reports_missing_system_input() -> Result<(), Box<dyn std::error::Error>> {
+    let Ok(env) = PipelineHarness::new() else {
+        return Ok(());
+    };
+
+    env.command()
+        .args(["run", "r2x_reeds.with_system_function"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("requires a System input"));
+
+    Ok(())
+}
+
+#[test]
+fn test_direct_plugin_rejects_input_for_nonconsumer() -> Result<(), Box<dyn std::error::Error>> {
+    let Ok(env) = PipelineHarness::new() else {
+        return Ok(());
+    };
+
+    let reeds_path = env.home_path().join("data/reeds-store");
+    env.command()
+        .args([
+            "run",
+            "r2x_reeds.parser",
+            "--path",
+            reeds_path.to_string_lossy().as_ref(),
+            "--solve-year",
+            "2032",
+            "--weather-year",
+            "2012",
+        ])
+        .write_stdin(r#"{"system":"reeds","status":"input"}"#)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "does not accept a System or JSON input",
+        ));
+
+    Ok(())
+}
+
+#[test]
+fn test_direct_plugin_keeps_plugin_diagnostics_off_stdout() -> Result<(), Box<dyn std::error::Error>>
+{
+    let Ok(env) = PipelineHarness::new() else {
+        return Ok(());
+    };
+
+    env.command()
+        .args(["run", "r2x_reeds.noisy_json"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("plugin diagnostic").not())
+        .stdout(predicate::str::contains(r#"{"status": "ok"}"#))
+        .stderr(predicate::str::contains("plugin diagnostic"));
+
+    Ok(())
+}
+
+#[test]
+fn test_direct_upgrader_keeps_plugin_diagnostics_off_stdout(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Ok(env) = PipelineHarness::new() else {
+        return Ok(());
+    };
+
+    let folder_path = env.home_path().join("upgrade-source");
+    env.command()
+        .args([
+            "run",
+            "r2x_reeds.upgrader",
+            "--folder-path",
+            folder_path.to_string_lossy().as_ref(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("upgrader diagnostic").not())
+        .stdout(predicate::str::contains(r#""upgraded": "reeds""#))
+        .stderr(predicate::str::contains("upgrader diagnostic"));
+
+    Ok(())
+}
+
+#[test]
+fn test_direct_plugin_json_output_creates_parent_directories(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Ok(env) = PipelineHarness::new() else {
+        return Ok(());
+    };
+
+    let output_path = env
+        .home_path()
+        .join("nested")
+        .join("results")
+        .join("output.json");
+    env.command()
+        .args([
+            "run",
+            "r2x_reeds.noisy_json",
+            "-o",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .assert()
+        .success();
+
+    let output: serde_json::Value = serde_json::from_slice(&fs::read(output_path)?)?;
+    assert_eq!(output, serde_json::json!({"status": "ok"}));
+    Ok(())
+}
+
+#[test]
+fn test_direct_plugin_pipe_preserves_time_series_sidecars() -> Result<(), Box<dyn std::error::Error>>
+{
+    let Ok(env) = PipelineHarness::new() else {
+        return Ok(());
+    };
+
+    let mut producer = env
+        .std_command()
+        .args(["run", "r2x_reeds.system_with_sidecar"])
+        .stdout(Stdio::piped())
+        .spawn()?;
+    let producer_stdout = producer.stdout.take().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            "producer stdout was not captured",
+        )
+    })?;
+    let consumer = env
+        .std_command()
+        .args(["run", "r2x_reeds.mark_streamed_system"])
+        .stdin(Stdio::from(producer_stdout))
+        .output()?;
+
+    assert!(producer.wait()?.success());
+    assert!(
+        consumer.status.success(),
+        "consumer stderr: {}",
+        String::from_utf8_lossy(&consumer.stderr)
+    );
+
+    let output: serde_json::Value = serde_json::from_slice(&consumer.stdout)?;
+    assert_eq!(output["status"], "streamed");
+    let sidecar = output["time_series"]["directory"]
+        .as_str()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing sidecar path"))?;
+    let sidecar = Path::new(sidecar);
+    assert!(sidecar.is_absolute());
+    assert!(sidecar.join("time_series_metadata.db").is_file());
+
+    Ok(())
+}
+
+#[test]
+fn test_direct_exporter_consumes_system_without_emitting_json(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Ok(env) = PipelineHarness::new() else {
+        return Ok(());
+    };
+
+    let mut producer = env
+        .std_command()
+        .args(["run", "r2x_reeds.system_with_sidecar"])
+        .stdout(Stdio::piped())
+        .spawn()?;
+    let producer_stdout = producer.stdout.take().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::BrokenPipe,
+            "producer stdout was not captured",
+        )
+    })?;
+    let consumer = env
+        .std_command()
+        .args(["run", "r2x_reeds.test_exporter"])
+        .stdin(Stdio::from(producer_stdout))
+        .output()?;
+
+    assert!(producer.wait()?.success());
+    assert!(
+        consumer.status.success(),
+        "exporter stderr: {}",
+        String::from_utf8_lossy(&consumer.stderr)
+    );
+    assert!(consumer.stdout.is_empty());
+
+    Ok(())
+}
+
+#[test]
+fn test_direct_plugin_output_materializes_system_sidecars_for_file_input(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Ok(env) = PipelineHarness::new() else {
+        return Ok(());
+    };
+
+    let output_path = env
+        .home_path()
+        .join("nested")
+        .join("exports")
+        .join("system.json");
+    for _ in 0..2 {
+        env.command()
+            .args([
+                "run",
+                "r2x_reeds.system_with_sidecar",
+                "-o",
+                output_path.to_string_lossy().as_ref(),
+            ])
+            .assert()
+            .success();
+    }
+
+    assert!(output_path.is_file());
+    let persisted: serde_json::Value = serde_json::from_slice(&fs::read(&output_path)?)?;
+    assert_eq!(persisted["time_series"]["directory"], "system_time_series");
+    assert!(output_path.parent().is_some_and(|parent| parent
+        .join("system_time_series/time_series_metadata.db")
+        .is_file()));
+
+    env.command()
+        .args([
+            "run",
+            "r2x_reeds.with_system_function",
+            "-i",
+            output_path.to_string_lossy().as_ref(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "\"status\": \"function-with-system\"",
+        ));
+
+    Ok(())
+}
+
+#[test]
+fn test_direct_plugin_rejects_file_input_and_piped_input_together(
+) -> Result<(), Box<dyn std::error::Error>> {
+    let Ok(env) = PipelineHarness::new() else {
+        return Ok(());
+    };
+
+    let input_path = env.home_path().join("input.json");
+    fs::write(&input_path, r#"{"system":"reeds"}"#)?;
+
+    env.command()
+        .args([
+            "run",
+            "r2x_reeds.with_system_function",
+            "--input",
+            input_path.to_string_lossy().as_ref(),
+        ])
+        .write_stdin(r#"{"system":"other"}"#)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "--input FILE cannot be combined with JSON supplied on stdin",
+        ));
 
     Ok(())
 }
@@ -485,16 +768,32 @@ fn test_direct_plugin_help_prefers_copy_pasteable_kebab_flags() {
     };
 
     env.command()
-        .args(["run", "plugin", "r2x_reeds.parser", "--show-help"])
+        .args(["run", "r2x_reeds.parser", "--show-help"])
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "r2x run plugin r2x_reeds.parser --path <value> --solve-year <value> --weather-year <value>",
+            "r2x run r2x_reeds.parser --path <value> --solve-year <value> --weather-year <value>",
         ))
         .stdout(predicate::str::contains("--weather-year"))
         .stdout(predicate::str::contains("Alias: --weather_year"))
         .stdout(predicate::str::contains("Compatibility:"))
         .stdout(predicate::str::contains("weather_year=<value>"));
+}
+
+#[test]
+fn test_pipeline_options_after_yaml_path_are_preserved() -> Result<(), Box<dyn std::error::Error>> {
+    let Ok(env) = PipelineHarness::new() else {
+        return Ok(());
+    };
+
+    let pipeline = env.reeds_pipeline();
+    env.command()
+        .args(["run", &pipeline, "--list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("reeds-test"));
+
+    Ok(())
 }
 
 #[test]
@@ -1209,6 +1508,24 @@ name = "r2x_reeds.system_with_sidecar"
 type = "function"
 module = "r2x_reeds.parser"
 function_name = "system_with_sidecar"
+
+[[packages.plugins]]
+name = "r2x_reeds.mark_streamed_system"
+type = "function"
+module = "r2x_reeds.parser"
+function_name = "mark_streamed_system"
+
+[[packages.plugins]]
+name = "r2x_reeds.noisy_json"
+type = "function"
+module = "r2x_reeds.parser"
+function_name = "noisy_json"
+
+[[packages.plugins]]
+name = "r2x_reeds.test_exporter"
+type = "function"
+module = "r2x_reeds.parser"
+function_name = "test_exporter"
 
 [[packages]]
 name = "r2x-sienna"

--- a/crates/r2x-cli/tests/python_plugins/r2x_core/system.py
+++ b/crates/r2x-cli/tests/python_plugins/r2x_core/system.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
+
+from r2x_core.utils.files import get_r2x_cache_path
 
 
 class System:
@@ -26,26 +29,36 @@ class System:
                 raise OSError("unable to open database file")
         return cls(data)
 
-    def to_json(self, path: str | Path | None = None) -> bytes | None:
-        payload = json.dumps(self.data, ensure_ascii=False)
+    def to_json(
+        self, path: str | Path | None = None, overwrite: bool = False
+    ) -> bytes | None:
+        data = json.loads(json.dumps(self.data, ensure_ascii=False))
+        time_series = data.get("time_series")
         if path is None:
-            return payload.encode("utf-8")
+            if isinstance(time_series, dict) and time_series.get("directory"):
+                sidecar_dir = get_r2x_cache_path() / f"{uuid4()}_time_series"
+                sidecar_dir.mkdir(parents=True, exist_ok=True)
+                (sidecar_dir / self.DB_FILENAME).write_text("sidecar", encoding="utf-8")
+                time_series["directory"] = str(sidecar_dir)
+            return json.dumps(data, ensure_ascii=False).encode("utf-8")
+
         output = Path(path)
-        output.parent.mkdir(parents=True, exist_ok=True)
-        output.write_text(payload, encoding="utf-8")
-        time_series = self.data.get("time_series")
+        if output.exists() and not overwrite:
+            raise FileExistsError(f"{output} already exists")
+        output.parent.mkdir(exist_ok=True)
         if isinstance(time_series, dict) and time_series.get("directory"):
             sidecar_dir = Path(time_series["directory"])
             if not sidecar_dir.is_absolute():
                 sidecar_dir = output.parent / sidecar_dir
             sidecar_dir.mkdir(parents=True, exist_ok=True)
             (sidecar_dir / self.DB_FILENAME).write_text("sidecar", encoding="utf-8")
+        output.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
         return None
 
     @classmethod
     def from_json(cls, source: bytes | str | Path) -> "System":
         if isinstance(source, bytes):
-            return cls(json.loads(source.decode("utf-8")))
+            return cls.from_dict(json.loads(source.decode("utf-8")), Path.cwd())
         if isinstance(source, Path):
             data = json.loads(source.read_text(encoding="utf-8"))
             return cls.from_dict(data, source.parent)

--- a/crates/r2x-cli/tests/python_plugins/r2x_reeds/parser.py
+++ b/crates/r2x-cli/tests/python_plugins/r2x_reeds/parser.py
@@ -59,7 +59,7 @@ def with_system_function(system) -> dict[str, str]:
 
 
 def system_with_sidecar():
-    """Return a path-serialized System with a relative sidecar bundle."""
+    """Return a System with a time-series sidecar."""
     from r2x_core.system import System
 
     return System(
@@ -69,3 +69,22 @@ def system_with_sidecar():
             "time_series": {"directory": "system_time_series"},
         }
     )
+
+
+def mark_streamed_system(system):
+    """Verify and annotate a System received through a direct stream."""
+    system.data["status"] = "streamed"
+    return system
+
+
+def noisy_json():
+    """Emit a plugin diagnostic while returning machine-readable output."""
+    print("plugin diagnostic")
+    return {"status": "ok"}
+
+
+def test_exporter(system):
+    """Consume a System as a terminal exporter sink."""
+    if system.data.get("system") != "reeds":
+        raise ValueError("expected a ReEDS System")
+    return None

--- a/crates/r2x-cli/tests/python_plugins/r2x_reeds/upgrader/data_upgrader.py
+++ b/crates/r2x-cli/tests/python_plugins/r2x_reeds/upgrader/data_upgrader.py
@@ -17,4 +17,5 @@ class ReEDSUpgrader:
             self.steps = list(steps)
 
     def run(self) -> str:
+        print("upgrader diagnostic")
         return f'{{"upgraded": "reeds", "folder": "{self.folder_path}"}}'

--- a/crates/r2x-python/src/errors.rs
+++ b/crates/r2x-python/src/errors.rs
@@ -35,6 +35,9 @@ pub enum BridgeError {
     #[error("Invalid artifact bundle: {0}")]
     InvalidArtifact(String),
 
+    #[error("Plugin stream error: {0}")]
+    Stream(String),
+
     #[error("Artifact-mode invocation is unsupported: {0}")]
     UnsupportedArtifactMode(String),
 

--- a/crates/r2x-python/src/plugin_invoker.rs
+++ b/crates/r2x-python/src/plugin_invoker.rs
@@ -115,37 +115,76 @@ pub struct PluginInvocationTimings {
     pub serialization: Duration,
 }
 
-/// Result of running a plugin through the Python bridge
+/// Direct input supplied to a plugin invocation.
+#[derive(Clone, Copy, Debug)]
+pub enum PluginInput<'a> {
+    /// JSON payload received from standard input.
+    Json(&'a str),
+    /// JSON entrypoint on disk, loaded relative to its sidecar bundle.
+    File(&'a Path),
+}
+
+/// Materialized result of running a plugin through the Python bridge.
+#[derive(Debug)]
+pub enum PluginInvocationOutput {
+    /// JSON text that should be emitted or written by the caller.
+    Json(String),
+    /// A System was written directly to the requested output path.
+    Persisted,
+    /// The plugin intentionally produced no stream output.
+    Empty,
+}
+
+/// Result of running a plugin through the Python bridge.
+#[derive(Debug)]
 pub struct PluginInvocationResult {
-    /// JSON text emitted by the plugin (may be `"null"`)
-    pub output: String,
-    /// Optional per-phase timings for diagnostics
+    /// Materialized plugin output.
+    pub output: PluginInvocationOutput,
+    /// Optional per-phase timings for diagnostics.
     pub timings: Option<PluginInvocationTimings>,
 }
 
 impl crate::python_bridge::Bridge {
-    pub fn invoke_plugin(
+    /// Invoke a plugin through the direct CLI interface.
+    ///
+    /// Direct invocations treat an unused stream input as an error, redirect
+    /// plugin writes away from stdout, and can persist System results directly
+    /// to a durable JSON entrypoint.
+    pub fn invoke_plugin_direct(
         &self,
         target: &str,
         config_json: &str,
-        stdin_json: Option<&str>,
+        input: Option<PluginInput<'_>>,
+        output_path: Option<&Path>,
         plugin_metadata: Option<&Plugin>,
     ) -> Result<PluginInvocationResult, BridgeError> {
         let runtime_bindings = plugin_metadata.map(build_runtime_bindings);
 
-        if let Some(bindings) = runtime_bindings.as_ref() {
-            if bindings.role == PluginRole::Upgrader {
-                logger::debug("Routing to upgrader plugin handler");
-                return self.invoke_upgrader_plugin(
-                    target,
-                    config_json,
-                    Some(bindings),
-                    plugin_metadata,
-                );
+        if runtime_bindings
+            .as_ref()
+            .is_some_and(|bindings| bindings.role == PluginRole::Upgrader)
+        {
+            if input.is_some() {
+                return Err(BridgeError::Stream(
+                    "upgrader plugins do not accept System input".to_string(),
+                ));
             }
+            return self.invoke_upgrader_plugin(
+                target,
+                config_json,
+                runtime_bindings.as_ref(),
+                plugin_metadata,
+                true,
+            );
         }
 
-        self.invoke_plugin_regular(target, config_json, stdin_json, runtime_bindings.as_ref())
+        self.invoke_plugin_regular_direct(
+            target,
+            config_json,
+            input,
+            output_path,
+            runtime_bindings.as_ref(),
+        )
     }
 
     pub fn invoke_plugin_with_bindings(
@@ -158,7 +197,13 @@ impl crate::python_bridge::Bridge {
         if let Some(bindings) = runtime_bindings {
             if bindings.role == PluginRole::Upgrader {
                 logger::debug("Routing to upgrader plugin handler (runtime bindings)");
-                return self.invoke_upgrader_plugin(target, config_json, Some(bindings), None);
+                return self.invoke_upgrader_plugin(
+                    target,
+                    config_json,
+                    Some(bindings),
+                    None,
+                    false,
+                );
             }
         }
 
@@ -244,10 +289,10 @@ mod tests {
     #[test]
     fn plugin_invocation_result_basics() {
         let result = PluginInvocationResult {
-            output: String::new(),
+            output: PluginInvocationOutput::Empty,
             timings: None,
         };
-        assert!(result.output.is_empty());
+        assert!(matches!(result.output, PluginInvocationOutput::Empty));
     }
 
     #[test]

--- a/crates/r2x-python/src/plugin_regular.rs
+++ b/crates/r2x-python/src/plugin_regular.rs
@@ -2,8 +2,8 @@
 
 use crate::errors::BridgeError;
 use crate::plugin_invoker::{
-    ArtifactBundle, ArtifactOutputKind, PluginArtifactInvocationResult, PluginInvocationResult,
-    PluginInvocationTimings,
+    ArtifactBundle, ArtifactOutputKind, PluginArtifactInvocationResult, PluginInput,
+    PluginInvocationOutput, PluginInvocationResult, PluginInvocationTimings,
 };
 use crate::python_bridge::Bridge;
 use once_cell::sync::Lazy;
@@ -160,52 +160,63 @@ fn load_system_artifact<'py>(
     })
 }
 
-fn load_exporter_system_artifact<'py>(
+fn input_json<'py>(
     py: pyo3::Python<'py>,
-    input: &ArtifactBundle,
+    input: PluginInput<'_>,
     json: &PythonJson<'py>,
 ) -> Result<Bound<'py, PyAny>, BridgeError> {
-    let entrypoint = python_path(py, &input.entrypoint_path())?;
-    let data = json.load_path(&entrypoint).map_err(|error| {
-        BridgeError::Python(format_python_error(
-            py,
-            error,
-            &format!(
-                "Failed to load exporter artifact {}",
-                input.entrypoint_path().display()
-            ),
-        ))
-    })?;
-    let root = python_path(py, input.root())?;
-    let system_module = PyModule::import(py, "infrasys")?;
-    let system_class = system_module.getattr("System")?;
-    let from_dict = system_class.getattr("from_dict")?;
-    let kwargs = PyDict::new(py);
-    kwargs.set_item("time_series_read_only", true)?;
-    from_dict
-        .call((data, root), Some(&kwargs))
-        .map_err(|error| {
+    match input {
+        PluginInput::Json(payload) => json.loads(payload).map_err(|error| {
             BridgeError::Python(format_python_error(
                 py,
                 error,
-                &format!(
-                    "Failed to load exporter System artifact {}",
-                    input.entrypoint_path().display()
-                ),
+                "Failed to parse JSON input from stdin",
             ))
-        })
+        }),
+        PluginInput::File(path) => {
+            let python_input_path = python_path(py, path)?;
+            json.load_path(&python_input_path).map_err(|error| {
+                BridgeError::Python(format_python_error(
+                    py,
+                    error,
+                    &format!("Failed to read JSON input {}", path.display()),
+                ))
+            })
+        }
+    }
 }
 
-enum ClassInput<'a> {
-    Inline(Option<&'a str>),
-    Artifact(Option<&'a ArtifactBundle>),
+struct RegularInvocationOptions<'a> {
+    input: Option<PluginInput<'a>>,
+    output_path: Option<&'a Path>,
+    reject_unused_input: bool,
+    redirect_plugin_stdout: bool,
 }
 
-impl ClassInput<'_> {
-    fn is_present(&self) -> bool {
-        match self {
-            Self::Inline(input) => input.is_some(),
-            Self::Artifact(input) => input.is_some(),
+fn input_system<'py>(
+    py: pyo3::Python<'py>,
+    input: PluginInput<'_>,
+) -> Result<Bound<'py, PyAny>, BridgeError> {
+    let system_module = PyModule::import(py, "r2x_core.system")?;
+    let system_class = system_module.getattr("System")?;
+    let from_json = system_class.getattr("from_json")?;
+    match input {
+        PluginInput::Json(payload) => from_json.call1((payload.as_bytes(),)).map_err(|error| {
+            BridgeError::Python(format_python_error(
+                py,
+                error,
+                "Failed to deserialize System input from stdin",
+            ))
+        }),
+        PluginInput::File(path) => {
+            let python_input_path = python_path(py, path)?;
+            from_json.call1((python_input_path,)).map_err(|error| {
+                BridgeError::Python(format_python_error(
+                    py,
+                    error,
+                    &format!("Failed to load System input {}", path.display()),
+                ))
+            })
         }
     }
 }
@@ -218,18 +229,32 @@ pub(crate) struct StdoutGuard<'py> {
 
 impl<'py> StdoutGuard<'py> {
     pub(crate) fn new(py: pyo3::Python<'py>, suppress: bool) -> Result<Self, BridgeError> {
-        let original = if suppress {
-            let sys = PyModule::import(py, "sys")?;
-            let io = PyModule::import(py, "io")?;
-            let original_stdout = sys.getattr("stdout")?;
-            let string_io = io.getattr("StringIO")?.call0()?;
-            sys.setattr("stdout", &string_io)?;
-            logger::debug("Python stdout suppressed");
-            Some(original_stdout.unbind())
-        } else {
-            None
-        };
-        Ok(Self { py, original })
+        if !suppress {
+            return Ok(Self { py, original: None });
+        }
+
+        let sys = PyModule::import(py, "sys")?;
+        let io = PyModule::import(py, "io")?;
+        let original_stdout = sys.getattr("stdout")?;
+        let string_io = io.getattr("StringIO")?.call0()?;
+        sys.setattr("stdout", &string_io)?;
+        logger::debug("Python stdout suppressed");
+        Ok(Self {
+            py,
+            original: Some(original_stdout.unbind()),
+        })
+    }
+
+    pub(crate) fn redirect_to_stderr(py: pyo3::Python<'py>) -> Result<Self, BridgeError> {
+        let sys = PyModule::import(py, "sys")?;
+        let original_stdout = sys.getattr("stdout")?;
+        let stderr = sys.getattr("stderr")?;
+        sys.setattr("stdout", &stderr)?;
+        logger::debug("Python stdout redirected to stderr");
+        Ok(Self {
+            py,
+            original: Some(original_stdout.unbind()),
+        })
     }
 }
 
@@ -260,12 +285,12 @@ static METHOD_STDIN_SIGNATURE_CACHE: Lazy<Mutex<HashMap<String, StdinSignatureSu
     Lazy::new(|| Mutex::new(HashMap::new()));
 
 fn should_parse_stdin_for_function_kwargs(
-    stdin_json: Option<&str>,
+    input: Option<PluginInput<'_>>,
     runtime_bindings: Option<&RuntimeBindings>,
 ) -> bool {
-    let Some(_stdin) = stdin_json else {
+    if input.is_none() {
         return false;
-    };
+    }
 
     match runtime_bindings {
         Some(bindings) => bindings
@@ -277,19 +302,24 @@ fn should_parse_stdin_for_function_kwargs(
     }
 }
 
-fn should_parse_stdin_for_exporter_context(stdin_json: Option<&str>, role: PluginRole) -> bool {
-    stdin_json.is_some() && role == PluginRole::Exporter
+fn should_parse_stdin_for_exporter_context(
+    input: Option<PluginInput<'_>>,
+    role: PluginRole,
+) -> bool {
+    input.is_some() && role == PluginRole::Exporter
 }
 
 fn ensure_parsed_stdin<'py>(
-    stdin_json: Option<&str>,
+    py: pyo3::Python<'py>,
+    input: Option<PluginInput<'_>>,
     json: &PythonJson<'py>,
     parsed_stdin: &mut Option<Bound<'py, PyAny>>,
-) -> PyResult<()> {
+) -> Result<(), BridgeError> {
     if parsed_stdin.is_none() {
-        if let Some(stdin) = stdin_json {
-            parsed_stdin.replace(json.loads(stdin)?);
-        }
+        let input = input.ok_or_else(|| {
+            BridgeError::Stream("plugin input was expected but not provided".to_string())
+        })?;
+        parsed_stdin.replace(input_json(py, input, json)?);
     }
     Ok(())
 }
@@ -302,8 +332,55 @@ impl Bridge {
         stdin_json: Option<&str>,
         runtime_bindings: Option<&RuntimeBindings>,
     ) -> Result<PluginInvocationResult, BridgeError> {
+        self.invoke_plugin_regular_with_options(
+            target,
+            config_json,
+            runtime_bindings,
+            RegularInvocationOptions {
+                input: stdin_json.map(PluginInput::Json),
+                output_path: None,
+                reject_unused_input: false,
+                redirect_plugin_stdout: false,
+            },
+        )
+    }
+
+    pub(crate) fn invoke_plugin_regular_direct(
+        &self,
+        target: &str,
+        config_json: &str,
+        input: Option<PluginInput<'_>>,
+        output_path: Option<&Path>,
+        runtime_bindings: Option<&RuntimeBindings>,
+    ) -> Result<PluginInvocationResult, BridgeError> {
+        self.invoke_plugin_regular_with_options(
+            target,
+            config_json,
+            runtime_bindings,
+            RegularInvocationOptions {
+                input,
+                output_path,
+                reject_unused_input: true,
+                redirect_plugin_stdout: true,
+            },
+        )
+    }
+
+    fn invoke_plugin_regular_with_options(
+        &self,
+        target: &str,
+        config_json: &str,
+        runtime_bindings: Option<&RuntimeBindings>,
+        options: RegularInvocationOptions<'_>,
+    ) -> Result<PluginInvocationResult, BridgeError> {
         pyo3::Python::attach(|py| {
-            let _guard = StdoutGuard::new(py, logger::get_no_stdout())?;
+            let _guard = if logger::get_no_stdout() {
+                StdoutGuard::new(py, true)?
+            } else if options.redirect_plugin_stdout {
+                StdoutGuard::redirect_to_stderr(py)?
+            } else {
+                StdoutGuard::new(py, false)?
+            };
 
             logger::debug_lazy(|| format!("Parsing target: {}", target));
             let parts: Vec<&str> = target.split(':').collect();
@@ -334,6 +411,21 @@ impl Bridge {
                 .map_err(|e| BridgeError::Python(format!("Config must be a JSON object: {}", e)))?
                 .clone();
 
+            let is_exporter =
+                runtime_bindings.is_some_and(|bindings| bindings.role == PluginRole::Exporter);
+            if is_exporter && options.output_path.is_some() {
+                return Err(BridgeError::Stream(
+                    "exporter plugins write their configured output and cannot use --output"
+                        .to_string(),
+                ));
+            }
+            if is_exporter && options.reject_unused_input && options.input.is_none() {
+                return Err(BridgeError::Stream(
+                    "exporter plugins require a System input from stdin or --input FILE"
+                        .to_string(),
+                ));
+            }
+
             logger::debug("Starting plugin invocation");
             let call_start = Instant::now();
             let result_py = if callable_path.contains('.') {
@@ -343,22 +435,23 @@ impl Bridge {
                     module_path,
                     callable_path,
                     &config_dict,
-                    ClassInput::Inline(stdin_json),
+                    options.input,
                     runtime_bindings,
                     &json,
+                    options.reject_unused_input,
                 )?
             } else {
                 logger::debug("Building kwargs for function invocation");
                 let stdin_obj =
-                    if should_parse_stdin_for_function_kwargs(stdin_json, runtime_bindings) {
-                        let Some(stdin) = stdin_json else {
-                            return Err(BridgeError::Python(
-                                "stdin unexpectedly missing while parsing function kwargs"
+                    if should_parse_stdin_for_function_kwargs(options.input, runtime_bindings) {
+                        let input = options.input.ok_or_else(|| {
+                            BridgeError::Stream(
+                                "plugin input was expected while preparing function arguments"
                                     .to_string(),
-                            ));
-                        };
+                            )
+                        })?;
                         logger::debug("Parsing stdin JSON for stdin kwarg injection");
-                        Some(json.loads(stdin)?)
+                        Some(input_json(py, input, &json)?)
                     } else {
                         None
                     };
@@ -369,10 +462,11 @@ impl Bridge {
                     &module,
                     module_path,
                     callable_path,
-                    stdin_json,
+                    options.input,
                     stdin_obj.as_ref(),
                     &kwargs,
                     &json,
+                    options.reject_unused_input,
                 )?
             };
             let call_elapsed = call_start.elapsed();
@@ -385,14 +479,12 @@ impl Bridge {
             });
             logger::debug("Plugin execution completed");
 
-            // For exporters, skip serialization - they write their own output
-            // and return PluginContext which we don't need to pass downstream
-            let is_exporter = runtime_bindings.is_some_and(|b| b.role == PluginRole::Exporter);
-
+            // Exporters are terminal sinks: they write their configured output
+            // and deliberately do not emit a JSON record to stdout.
             if is_exporter {
                 logger::debug("Exporter plugin completed, skipping result serialization");
                 return Ok(PluginInvocationResult {
-                    output: "{}".to_string(),
+                    output: PluginInvocationOutput::Empty,
                     timings: Some(PluginInvocationTimings {
                         python_invocation: call_elapsed,
                         serialization: Duration::ZERO,
@@ -429,41 +521,48 @@ impl Bridge {
                     result_unwrapped
                 };
 
-            let (json_str, ser_elapsed) = if result_to_serialize.hasattr("to_json")? {
-                let ser_start = Instant::now();
-                let to_json_result = result_to_serialize.call_method0("to_json")?;
-                let json_str = if let Ok(json_bytes) = to_json_result.extract::<Vec<u8>>() {
-                    String::from_utf8(json_bytes).map_err(|e| {
-                        BridgeError::Python(format!("Invalid UTF-8 in JSON output: {}", e))
-                    })?
+            let ser_start = Instant::now();
+            let output = if result_to_serialize.hasattr("to_json")? {
+                if let Some(output_path) = options.output_path {
+                    let python_output_path = python_path(py, output_path)?;
+                    ensure_artifact_parent(&python_output_path)?;
+                    let kwargs = PyDict::new(py);
+                    kwargs.set_item("overwrite", true)?;
+                    result_to_serialize
+                        .call_method("to_json", (python_output_path,), Some(&kwargs))
+                        .map_err(|error| {
+                            BridgeError::Python(format_python_error(
+                                py,
+                                error,
+                                &format!("Failed to write System output {}", output_path.display()),
+                            ))
+                        })?;
+                    PluginInvocationOutput::Persisted
                 } else {
-                    json.dumps(&result_to_serialize)?
-                };
-                let ser_elapsed = ser_start.elapsed();
-                logger::debug_lazy(|| {
-                    format!(
-                        "Serialization for '{}' took {}",
-                        callable_path,
-                        format_duration(ser_elapsed)
-                    )
-                });
-                (json_str, ser_elapsed)
+                    let to_json_result = result_to_serialize.call_method0("to_json")?;
+                    let json_str = if let Ok(json_bytes) = to_json_result.extract::<Vec<u8>>() {
+                        String::from_utf8(json_bytes).map_err(|error| {
+                            BridgeError::Python(format!("Invalid UTF-8 in JSON output: {error}"))
+                        })?
+                    } else {
+                        json.dumps(&result_to_serialize)?
+                    };
+                    PluginInvocationOutput::Json(json_str)
+                }
             } else {
-                let ser_start = Instant::now();
-                let json_str = json.dumps(&result_to_serialize)?;
-                let ser_elapsed = ser_start.elapsed();
-                logger::debug_lazy(|| {
-                    format!(
-                        "Serialization for '{}' took {}",
-                        callable_path,
-                        format_duration(ser_elapsed)
-                    )
-                });
-                (json_str, ser_elapsed)
+                PluginInvocationOutput::Json(json.dumps(&result_to_serialize)?)
             };
+            let ser_elapsed = ser_start.elapsed();
+            logger::debug_lazy(|| {
+                format!(
+                    "Serialization for '{}' took {}",
+                    callable_path,
+                    format_duration(ser_elapsed)
+                )
+            });
 
             Ok(PluginInvocationResult {
-                output: json_str,
+                output,
                 timings: Some(PluginInvocationTimings {
                     python_invocation: call_elapsed,
                     serialization: ser_elapsed,
@@ -572,6 +671,8 @@ impl Bridge {
                 })?
                 .clone();
 
+            let input_path = input.map(ArtifactBundle::entrypoint_path);
+            let plugin_input = input_path.as_deref().map(PluginInput::File);
             let call_start = Instant::now();
             let result_py = if callable_path.contains('.') {
                 Self::invoke_class_callable(
@@ -580,9 +681,10 @@ impl Bridge {
                     module_path,
                     callable_path,
                     &config_dict,
-                    ClassInput::Artifact(input),
+                    plugin_input,
                     runtime_bindings,
                     &json,
+                    false,
                 )?
             } else {
                 let stdin_obj = if input.is_some()
@@ -694,9 +796,10 @@ impl Bridge {
         module_path: &str,
         callable_path: &str,
         config_dict: &pyo3::Bound<'py, PyDict>,
-        input: ClassInput<'_>,
+        input: Option<PluginInput<'_>>,
         runtime_bindings: Option<&RuntimeBindings>,
         json: &PythonJson<'py>,
+        reject_unused_input: bool,
     ) -> Result<pyo3::Bound<'py, PyAny>, BridgeError> {
         let parts: Vec<&str> = callable_path.split('.').collect();
         if parts.len() != 2 {
@@ -768,33 +871,14 @@ impl Bridge {
         };
 
         let mut parsed_stdin_obj: Option<Bound<'py, PyAny>> = None;
-        let system_instance = match &input {
-            ClassInput::Inline(stdin_json)
-                if should_parse_stdin_for_exporter_context(*stdin_json, bindings.role) =>
-            {
-                logger::step("Deserializing system from stdin for PluginContext");
-                ensure_parsed_stdin(*stdin_json, json, &mut parsed_stdin_obj)?;
-                let stdin = parsed_stdin_obj
-                    .as_ref()
-                    .ok_or_else(|| PyValueError::new_err("stdin expected but not provided"))?;
-
-                let system_module = PyModule::import(py, "infrasys")?;
-                let system_class = system_module.getattr("System")?;
-                let from_dict = system_class.getattr("from_dict")?;
-
-                let tempfile = PyModule::import(py, "tempfile")?;
-                let mkdtemp = tempfile.getattr("mkdtemp")?;
-                let temp_dir = mkdtemp.call0()?.extract::<String>()?;
-
-                let kwargs_dict = PyDict::new(py);
-                kwargs_dict.set_item("time_series_read_only", true)?;
-                Some(from_dict.call((stdin, temp_dir), Some(&kwargs_dict))?)
-            }
-            ClassInput::Artifact(Some(bundle)) if bindings.role == PluginRole::Exporter => {
-                logger::step("Deserializing System artifact for exporter PluginContext");
-                Some(load_exporter_system_artifact(py, bundle, json)?)
-            }
-            _ => None,
+        let system_instance = if should_parse_stdin_for_exporter_context(input, bindings.role) {
+            logger::step("Deserializing system input for exporter PluginContext");
+            let input = input.ok_or_else(|| {
+                BridgeError::Stream("exporter requires a System input".to_string())
+            })?;
+            Some(input_system(py, input)?)
+        } else {
+            None
         };
 
         let ctx = Bridge::instantiate_plugin_context(
@@ -855,7 +939,7 @@ impl Bridge {
             ))
         })?;
 
-        let signature_support = if input.is_present() {
+        let signature_support = if input.is_some() || reject_unused_input {
             let signature_cache_key = format!("{module_path}:{class_name}.{actual_method_name}");
             match method_stdin_support_cached(&signature_cache_key, &method) {
                 Ok(result) => result,
@@ -873,34 +957,19 @@ impl Bridge {
             StdinSignatureSupport::default()
         };
 
+        if signature_support.accepts_system && input.is_none() && reject_unused_input {
+            return Err(BridgeError::Stream(format!(
+                "plugin method '{}.{}' requires a System input",
+                class_name, actual_method_name
+            )));
+        }
+
         if signature_support.accepts_stdin {
-            let stdin = match &input {
-                ClassInput::Inline(stdin_json) => {
-                    ensure_parsed_stdin(*stdin_json, json, &mut parsed_stdin_obj)?;
-                    parsed_stdin_obj
-                        .as_ref()
-                        .ok_or_else(|| PyValueError::new_err("stdin expected but not provided"))?
-                        .clone()
-                }
-                ClassInput::Artifact(Some(bundle)) => {
-                    let path = python_path(py, &bundle.entrypoint_path())?;
-                    json.load_path(&path).map_err(|error| {
-                        BridgeError::Python(format_python_error(
-                            py,
-                            error,
-                            &format!(
-                                "Failed to load stdin artifact {}",
-                                bundle.entrypoint_path().display()
-                            ),
-                        ))
-                    })?
-                }
-                ClassInput::Artifact(None) => {
-                    return Err(BridgeError::Python(
-                        "stdin expected but no input artifact was provided".to_string(),
-                    ));
-                }
-            };
+            ensure_parsed_stdin(py, input, json, &mut parsed_stdin_obj)?;
+            let stdin = parsed_stdin_obj
+                .as_ref()
+                .ok_or_else(|| BridgeError::Stream("plugin input was not parsed".to_string()))?
+                .clone();
             method.call1((stdin,)).map_err(|e| {
                 BridgeError::Python(format_python_error(
                     method.py(),
@@ -910,22 +979,9 @@ impl Bridge {
             })
         } else if signature_support.accepts_system {
             logger::step("Method has system - deserializing input to System object");
-            let system_obj = match &input {
-                ClassInput::Inline(stdin_json) => {
-                    let json_bytes =
-                        stdin_payload_bytes(*stdin_json, parsed_stdin_obj.as_ref(), json)?;
-                    let system_module = PyModule::import(py, "r2x_core.system")?;
-                    let system_class = system_module.getattr("System")?;
-                    let from_json = system_class.getattr("from_json")?;
-                    from_json.call1((json_bytes.as_slice(),))?
-                }
-                ClassInput::Artifact(Some(bundle)) => load_system_artifact(py, bundle)?,
-                ClassInput::Artifact(None) => {
-                    return Err(BridgeError::Python(
-                        "system expected but no input artifact was provided".to_string(),
-                    ));
-                }
-            };
+            let input = input
+                .ok_or_else(|| BridgeError::Stream("plugin requires a System input".to_string()))?;
+            let system_obj = input_system(py, input)?;
             method.call1((system_obj,)).map_err(|e| {
                 BridgeError::Python(format_python_error(
                     method.py(),
@@ -934,7 +990,13 @@ impl Bridge {
                 ))
             })
         } else {
-            if input.is_present() {
+            if input.is_some() {
+                if reject_unused_input {
+                    return Err(BridgeError::Stream(format!(
+                        "plugin method '{}.{}' does not accept a System or JSON input",
+                        class_name, actual_method_name
+                    )));
+                }
                 logger::debug_lazy(|| {
                     format!(
                         "Method '{}.{}' does not declare 'system'/'stdin'; skipping stdin payload",
@@ -958,10 +1020,11 @@ impl Bridge {
         module: &pyo3::Bound<'py, PyModule>,
         module_path: &str,
         callable_path: &str,
-        stdin_json: Option<&str>,
+        input: Option<PluginInput<'_>>,
         stdin_obj: Option<&pyo3::Bound<'py, PyAny>>,
         kwargs: &pyo3::Bound<'py, PyDict>,
         json: &PythonJson<'py>,
+        reject_unused_input: bool,
     ) -> Result<pyo3::Bound<'py, PyAny>, BridgeError> {
         logger::debug_lazy(|| format!("Function pattern: {}", callable_path));
         let func = module.getattr(callable_path).map_err(|e| {
@@ -973,7 +1036,7 @@ impl Bridge {
         })?;
 
         logger::step("Function kwargs prepared (before system injection)");
-        let signature_support = if stdin_json.is_some() || stdin_obj.is_some() {
+        let signature_support = if input.is_some() || stdin_obj.is_some() || reject_unused_input {
             let signature_cache_key = format!("{module_path}:{callable_path}");
             match method_stdin_support_cached(&signature_cache_key, &func) {
                 Ok(result) => result,
@@ -994,40 +1057,38 @@ impl Bridge {
         if signature_support.accepts_stdin && !kwargs.contains("stdin")? {
             if let Some(stdin) = stdin_obj {
                 kwargs.set_item("stdin", stdin)?;
-            } else if let Some(stdin) = stdin_json {
-                kwargs.set_item("stdin", json.loads(stdin)?)?;
+            } else if let Some(input) = input {
+                kwargs.set_item("stdin", input_json(py, input, json)?)?;
             }
         }
 
         if signature_support.accepts_system {
-            logger::step("Function has stdin - deserializing to System object");
-            let json_bytes = stdin_payload_bytes(stdin_json, stdin_obj, json)?;
-
-            let system_module = PyModule::import(py, "r2x_core.system")?;
-            let system_class = system_module.getattr("System")?;
-            let from_json = system_class.getattr("from_json")?;
-            let system_obj = from_json.call1((json_bytes.as_slice(),))?;
-            kwargs.set_item("system", system_obj)?;
-        } else if stdin_obj.is_some() {
-            if signature_support.accepts_stdin {
-                logger::debug_lazy(|| {
-                    format!(
-                        "Function '{}' accepts 'stdin'; skipping System deserialization",
-                        callable_path
-                    )
-                });
-            } else {
-                logger::debug_lazy(|| {
-                    format!(
-                        "Function '{}' does not declare 'system'/'stdin'; skipping stdin payload",
-                        callable_path
-                    )
-                });
+            if let Some(input) = input {
+                logger::step("Function has system - deserializing input to System object");
+                kwargs.set_item("system", input_system(py, input)?)?;
+            } else if reject_unused_input {
+                return Err(BridgeError::Stream(format!(
+                    "plugin '{}' requires a System input",
+                    callable_path
+                )));
             }
-        } else if stdin_json.is_some() && !signature_support.accepts_any() {
+        } else if input.is_some() && !signature_support.accepts_any() {
+            if reject_unused_input {
+                return Err(BridgeError::Stream(format!(
+                    "plugin '{}' does not accept a System or JSON input",
+                    callable_path
+                )));
+            }
             logger::debug_lazy(|| {
                 format!(
                     "Function '{}' does not declare 'system'/'stdin'; skipping stdin payload",
+                    callable_path
+                )
+            });
+        } else if stdin_obj.is_some() && signature_support.accepts_stdin {
+            logger::debug_lazy(|| {
+                format!(
+                    "Function '{}' accepts 'stdin'; skipping System deserialization",
                     callable_path
                 )
             });
@@ -1305,6 +1366,7 @@ fn method_stdin_support(method: &pyo3::Bound<'_, PyAny>) -> PyResult<StdinSignat
     Ok(support)
 }
 
+#[cfg(test)]
 fn stdin_payload_bytes<'py>(
     stdin_json: Option<&str>,
     stdin_obj: Option<&pyo3::Bound<'py, PyAny>>,
@@ -1477,7 +1539,9 @@ mod tests {
         remove_cached_method_signature, should_parse_stdin_for_exporter_context,
         should_parse_stdin_for_function_kwargs, stdin_payload_bytes, PythonJson,
     };
-    use crate::plugin_invoker::{ArtifactBundle, ArtifactOutputKind};
+    use crate::plugin_invoker::{
+        ArtifactBundle, ArtifactOutputKind, PluginInput, PluginInvocationOutput,
+    };
     use crate::python_bridge::Bridge;
     use pyo3::types::{PyAnyMethods, PyDict, PyDictMethods, PyModule};
     use r2x_manifest::runtime::RuntimeBindings;
@@ -2047,10 +2111,11 @@ def run():
                 &module,
                 "malformed_stdin_ignored_test",
                 "run",
-                Some("{not-json"),
+                Some(PluginInput::Json("{not-json")),
                 None,
                 &kwargs,
                 &json,
+                false,
             )
             .map_err(|error| error.to_string())?;
 
@@ -2097,10 +2162,11 @@ def run(stdin):
                 &module,
                 "stdin_only_function_test",
                 "run",
-                Some(r#"{"ok":true}"#),
+                Some(PluginInput::Json(r#"{"ok":true}"#)),
                 Some(&stdin_obj),
                 &kwargs,
                 &json,
+                false,
             )
             .map_err(|error| error.to_string())?;
 
@@ -2141,10 +2207,11 @@ def run(stdin):
                 &module,
                 "stdin_injection_fallback_test",
                 "run",
-                Some(r#"{"ok":true}"#),
+                Some(PluginInput::Json(r#"{"ok":true}"#)),
                 None,
                 &kwargs,
                 &json,
+                false,
             )
             .map_err(|error| error.to_string())?;
 
@@ -2178,7 +2245,7 @@ def run(stdin):
             requires_store: false,
         };
         assert!(should_parse_stdin_for_function_kwargs(
-            Some(r#"{"ok":true}"#),
+            Some(PluginInput::Json(r#"{"ok":true}"#)),
             Some(&with_stdin)
         ));
 
@@ -2194,11 +2261,11 @@ def run(stdin):
             ..with_stdin
         };
         assert!(!should_parse_stdin_for_function_kwargs(
-            Some(r#"{"ok":true}"#),
+            Some(PluginInput::Json(r#"{"ok":true}"#)),
             Some(&without_stdin)
         ));
         assert!(should_parse_stdin_for_function_kwargs(
-            Some(r#"{"ok":true}"#),
+            Some(PluginInput::Json(r#"{"ok":true}"#)),
             None
         ));
         assert!(!should_parse_stdin_for_function_kwargs(
@@ -2210,7 +2277,7 @@ def run(stdin):
     #[test]
     fn should_parse_stdin_for_exporter_context_requires_exporter_and_stdin() {
         assert!(should_parse_stdin_for_exporter_context(
-            Some(r#"{"ok":true}"#),
+            Some(PluginInput::Json(r#"{"ok":true}"#)),
             r2x_manifest::runtime::PluginRole::Exporter
         ));
         assert!(!should_parse_stdin_for_exporter_context(
@@ -2218,7 +2285,7 @@ def run(stdin):
             r2x_manifest::runtime::PluginRole::Exporter
         ));
         assert!(!should_parse_stdin_for_exporter_context(
-            Some(r#"{"ok":true}"#),
+            Some(PluginInput::Json(r#"{"ok":true}"#)),
             r2x_manifest::runtime::PluginRole::Parser
         ));
     }
@@ -2444,7 +2511,10 @@ obj = NotSerializable()
                     )),
                 )
                 .map_err(|error| error.to_string())?;
-            assert_eq!(inline_exporter.output, "{}");
+            assert!(matches!(
+                inline_exporter.output,
+                PluginInvocationOutput::Empty
+            ));
 
             let missing_root = temp.path().join("missing-input");
             std::fs::create_dir_all(&missing_root).map_err(|error| error.to_string())?;

--- a/crates/r2x-python/src/plugin_upgrader.rs
+++ b/crates/r2x-python/src/plugin_upgrader.rs
@@ -1,7 +1,7 @@
 //! Upgrader plugin invocation
 
 use crate::errors::BridgeError;
-use crate::plugin_invoker::PluginInvocationResult;
+use crate::plugin_invoker::{PluginInvocationOutput, PluginInvocationResult};
 use crate::plugin_regular::{format_err_result, format_python_error, PythonJson, StdoutGuard};
 use crate::python_bridge::Bridge;
 use pyo3::types::{PyAny, PyAnyMethods, PyDict, PyDictMethods, PyModule};
@@ -18,9 +18,16 @@ impl Bridge {
         config_json: &str,
         runtime_bindings: Option<&RuntimeBindings>,
         _plugin_metadata: Option<&Plugin>, // kept for API consistency across invoke methods
+        redirect_plugin_stdout: bool,
     ) -> Result<PluginInvocationResult, BridgeError> {
         pyo3::Python::attach(|py| {
-            let _guard = StdoutGuard::new(py, logger::get_no_stdout())?;
+            let _guard = if logger::get_no_stdout() {
+                StdoutGuard::new(py, true)?
+            } else if redirect_plugin_stdout {
+                StdoutGuard::redirect_to_stderr(py)?
+            } else {
+                StdoutGuard::new(py, false)?
+            };
 
             logger::debug_lazy(|| format!("Invoking upgrader plugin: {}", target));
             let parts: Vec<&str> = target.split(':').collect();
@@ -76,14 +83,14 @@ impl Bridge {
                     ))
                 })?;
                 Ok(PluginInvocationResult {
-                    output,
+                    output: PluginInvocationOutput::Json(output),
                     timings: None,
                 })
             } else {
                 logger::debug("Upgrader missing run() method, invoking registered steps directly");
                 let output = Self::invoke_registered_steps(&instance)?;
                 Ok(PluginInvocationResult {
-                    output,
+                    output: PluginInvocationOutput::Json(output),
                     timings: None,
                 })
             }

--- a/docs/torc-plugin-streams.md
+++ b/docs/torc-plugin-streams.md
@@ -1,0 +1,166 @@
+# Use r2x plugin streams in Torc
+
+This how-to is for Torc users who want r2x plugins to compose as ordinary Unix commands while Torc owns job expansion, resources, and durable job dependencies.
+
+## Choose the boundary
+
+Use a Unix pipe for work that belongs in **one Torc job**:
+
+```bash
+set -o pipefail
+r2x run r2x-reeds.reeds-parser \
+  --path data/runs/2026_06_18_USA_defaults \
+  --solve-year 2050 \
+  --weather-year 2012 \
+  --scenario A1 |
+r2x run r2x-reeds.add-pcm-defaults \
+  --pcm-defaults-fpath config/r2x/pcm_defaults.json |
+r2x run r2x-reeds-to-plexos.reeds-to-plexos \
+  --models '["r2x_reeds.models","r2x_plexos.models"]' |
+r2x run r2x-plexos.plexos-exporter \
+  --output-path artifacts/A1/2050/plexos \
+  --model-name Geothermal_A1 \
+  --horizon-year 2050 \
+  --weather-year 2012 \
+  --template PLEXOS10.0
+```
+
+A System-producing plugin writes one JSON document to stdout. Its time-series sidecars are stored in r2x's cache-backed stream location, and the JSON embeds the absolute sidecar path. A following `r2x run` deserializes that System from stdin. Diagnostics go to stderr, and exporters are terminal sinks: they write their configured files and emit no JSON record.
+
+Use `set -o pipefail` so Torc receives a failure from any command in the pipe.
+
+Use `-o` and `-i` for a **durable boundary between Torc jobs**:
+
+```bash
+r2x run r2x-reeds.reeds-parser \
+  --path data/runs/2026_06_18_USA_defaults \
+  --solve-year 2050 \
+  --weather-year 2012 \
+  --scenario A1 \
+  -o artifacts/A1/2050/infrasys.json
+
+r2x run r2x-reeds.add-pcm-defaults \
+  -i artifacts/A1/2050/infrasys.json \
+  --pcm-defaults-fpath config/r2x/pcm_defaults.json
+```
+
+For a System result, `-o artifacts/A1/2050/infrasys.json` creates missing parent directories, replaces an existing JSON entrypoint, and creates both:
+
+```text
+artifacts/A1/2050/
+├── infrasys.json
+└── infrasys_time_series/
+```
+
+The durable JSON contains a relative sidecar directory, so consume it with `-i infrasys.json`, not `cat infrasys.json | ...`.
+
+## Streamed generation with Torc file dependencies
+
+Torc's `input_files` and `output_files` name durable filesystem artifacts. They do not represent the live System passed through the pipe. Declare the concrete exporter output that a later job consumes.
+
+```yaml
+name: geothermal_reeds_to_plexos
+
+parameters:
+  scenario: [A1, A2, A3, B1, B2, B3, C1, C2, C3]
+  solve_year: [2050]
+  weather_year: [2012]
+
+files:
+  - name: plexos_xml_{scenario}_{solve_year}_{weather_year}
+    path: artifacts/{scenario}/{solve_year}/plexos/Geothermal_{scenario}_{weather_year}_{solve_year}.xml
+    use_parameters: [scenario, solve_year, weather_year]
+
+jobs:
+  - name: generate_A_{scenario}_{solve_year}_{weather_year}
+    parameters:
+      scenario: [A1, A2, A3]
+    use_parameters: [solve_year, weather_year]
+    command: |
+      set -o pipefail
+      r2x run r2x-reeds.reeds-parser \
+        --path data/runs/2026_06_18_USA_defaults \
+        --solve-year {solve_year} \
+        --weather-year {weather_year} \
+        --case-name geothermal-{scenario} \
+        --scenario {scenario} |
+      r2x run r2x-reeds-to-plexos.reeds-to-plexos \
+        --models '["r2x_reeds.models","r2x_plexos.models"]' |
+      r2x run r2x-plexos.plexos-exporter \
+        --output-path artifacts/{scenario}/{solve_year}/plexos \
+        --model-name Geothermal_{scenario} \
+        --horizon-year {solve_year} \
+        --weather-year {weather_year} \
+        --template PLEXOS10.0
+    output_files:
+      - plexos_xml_{scenario}_{solve_year}_{weather_year}
+
+  - name: validate_A_{scenario}_{solve_year}_{weather_year}
+    parameters:
+      scenario: [A1, A2, A3]
+    use_parameters: [solve_year, weather_year]
+    command: >
+      python scripts/geothermal_workflow.py validate
+      --scenario {scenario} --variant A
+      --solve-year {solve_year} --weather-year {weather_year}
+      --output artifacts/{scenario}/{solve_year}
+    input_files:
+      - plexos_xml_{scenario}_{solve_year}_{weather_year}
+```
+
+The `plexos_xml_*` logical file creates the generation-to-validation dependency. B and C use the same shape; they only add their variant-specific modifiers to the live pipe.
+
+## Durable staged generation with Torc file dependencies
+
+When parsing must be scheduled, retried, or inspected separately, make the System entrypoint an explicit Torc artifact.
+
+```yaml
+files:
+  - name: parsed_system_{scenario}_{solve_year}_{weather_year}
+    path: artifacts/{scenario}/{solve_year}/infrasys.json
+    use_parameters: [scenario, solve_year, weather_year]
+
+jobs:
+  - name: parse_{scenario}_{solve_year}_{weather_year}
+    use_parameters: [scenario, solve_year, weather_year]
+    command: >
+      r2x run r2x-reeds.reeds-parser
+      --path data/runs/2026_06_18_USA_defaults
+      --solve-year {solve_year}
+      --weather-year {weather_year}
+      --scenario {scenario}
+      -o artifacts/{scenario}/{solve_year}/infrasys.json
+    output_files:
+      - parsed_system_{scenario}_{solve_year}_{weather_year}
+
+  - name: generate_A_{scenario}_{solve_year}_{weather_year}
+    parameters:
+      scenario: [A1, A2, A3]
+    use_parameters: [solve_year, weather_year]
+    command: |
+      set -o pipefail
+      r2x run r2x-reeds-to-plexos.reeds-to-plexos \
+        -i artifacts/{scenario}/{solve_year}/infrasys.json \
+        --models '["r2x_reeds.models","r2x_plexos.models"]' |
+      r2x run r2x-plexos.plexos-exporter \
+        --output-path artifacts/{scenario}/{solve_year}/plexos \
+        --model-name Geothermal_{scenario} \
+        --horizon-year {solve_year} \
+        --weather-year {weather_year} \
+        --template PLEXOS10.0
+    input_files:
+      - parsed_system_{scenario}_{solve_year}_{weather_year}
+```
+
+`parsed_system_*` tracks the JSON entrypoint. Its adjacent `infrasys_time_series/` directory is part of the same r2x System bundle and must remain co-located on the shared filesystem.
+
+## Fan in parameterized outputs
+
+A parameterized consumer creates one consumer per parameter combination. For one job that consumes all matching producer files, use `input_file_regexes` instead:
+
+```yaml
+- name: aggregate_results
+  command: python aggregate.py --input-dir=/results --output=/results/summary.csv
+  input_file_regexes:
+    - '^metrics_lr.*$'
+```


### PR DESCRIPTION
## Summary
- Add the short direct form: `r2x run <plugin-ref>` (the explicit `r2x run plugin …` form remains supported).
- Make direct plugins Unix-composable: compatible commands consume a System/JSON from stdin, System results write one clean JSON document to stdout, and diagnostics go to stderr.
- Add `-i/--input` and System-aware `-o/--output`; durable output creates the JSON entrypoint plus adjacent time-series sidecars.
- Document Torc live-pipe and durable file-boundary workflows, including parameterized `input_files`/`output_files` dependencies.

## Behavioral notes
- A no-`-o` System stream uses r2x-core's cache-backed sidecar location and is intended for commands within the same Torc job.
- `-o` creates missing parent directories and replaces the JSON entrypoint; consume the durable bundle with `-i`, not shell redirection.
- Exporters are terminal sinks: they require System input, write their configured files, and emit no JSON record.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo +1.97.1 hawk check --target-dir target/hawk -D warnings`
- YAML fences in `docs/torc-plugin-streams.md` parsed with Ruby `YAML.safe_load`

## Integration note
This touches `crates/r2x-python/src/plugin_regular.rs`, which also changes in #166. Rebase or resolve that overlap if #166 lands first.
