### PR TITLE
fix(cli): stream UV install progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,13 @@ r2x log set --help
 
 Persisted logging defaults can be set with `r2x log set ...`.
 
+Plugin installation and `r2x sync --upgrade` print an immediate phase status to
+stderr and stream uv diagnostics there. uv's progress display is enabled only
+for an interactive terminal; pipes, CI, `NO_COLOR`, and `TERM=dumb` receive
+plain, line-oriented status instead. Use `-q` or `-qq` to suppress status and
+uv informational output, and `-v` or `-vv` to pass diagnostic verbosity through to uv. stdin is
+inherited, so private Git and SSH installs can still prompt for credentials.
+
 ## Architecture
 
 ```mermaid

--- a/crates/r2x-cli/src/commands/plugins/clean.rs
+++ b/crates/r2x-cli/src/commands/plugins/clean.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::process::Command;
 
 use crate::commands::config::clean_cache_folder;
 use crate::plugins::error::PluginError;
@@ -7,6 +6,7 @@ use colored::Colorize;
 use r2x_logger as logger;
 
 use crate::commands::plugins::context::PluginContext;
+use crate::uv;
 
 pub fn clean_manifest(yes: bool, ctx: &mut PluginContext) -> Result<(), PluginError> {
     if !yes {
@@ -54,26 +54,16 @@ pub fn clean_manifest(yes: bool, ctx: &mut PluginContext) -> Result<(), PluginEr
 }
 
 fn uninstall_package(uv_path: &str, python_path: &str, package_name: &str) {
-    logger::debug(&format!(
-        "Running: {uv_path} pip uninstall --python {python_path} {package_name}"
-    ));
+    let uninstall_args = vec![
+        "pip".to_string(),
+        "uninstall".to_string(),
+        "--python".to_string(),
+        python_path.to_string(),
+        package_name.to_string(),
+    ];
 
-    let output = Command::new(uv_path)
-        .args(["pip", "uninstall", "--python", python_path, package_name])
-        .output();
-
-    match output {
-        Ok(o) if o.status.success() => {
-            logger::info(&format!("Uninstalled '{package_name}'"));
-        }
-        Ok(o) => {
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            logger::debug(&format!("Failed to uninstall '{package_name}': {stderr}"));
-        }
-        Err(e) => {
-            logger::warn(&format!(
-                "Failed to run uv pip uninstall for '{package_name}': {e}"
-            ));
-        }
+    match uv::run(uv_path, "Uninstalling", package_name, uninstall_args) {
+        Ok(_) => logger::status(&format!("Uninstalled '{package_name}'")),
+        Err(error) => logger::warn(&error.to_string()),
     }
 }

--- a/crates/r2x-cli/src/commands/plugins/install.rs
+++ b/crates/r2x-cli/src/commands/plugins/install.rs
@@ -5,12 +5,12 @@ use crate::plugins::{
     install::get_package_info,
     package_spec::{build_package_spec, extract_package_name},
 };
+use crate::uv;
 use colored::Colorize;
 use r2x_logger as logger;
 use r2x_manifest::package_discovery::PackageDiscoverer;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 
 /// Options for git-based package installation
 pub struct GitOptions {
@@ -41,7 +41,7 @@ pub fn install_plugin(
 
     // Check if this is a workspace installation
     if is_workspace_package(&package_spec)? {
-        logger::info("Detected workspace repository, installing all members...");
+        logger::status("Detected workspace repository, installing all members...");
         // Just install the workspace - uv will handle all members
         run_pip_install(
             &ctx.uv_path,
@@ -55,7 +55,7 @@ pub fn install_plugin(
         // Now discover all packages with entry points (like sync command).
         // The install transaction just mutated site-packages, so rebuild plugin
         // metadata from disk instead of trusting any existing manifest entries.
-        logger::info("Discovering plugins from installed packages...");
+        logger::status("Discovering plugins from installed packages...");
         return discover_all_installed_packages(ctx, true, total_start);
     }
 
@@ -88,8 +88,6 @@ pub fn install_plugin(
             check_start.elapsed()
         ));
     } else {
-        // Print status without spinner since we need interactive terminal for SSH prompts
-        logger::info(&format!("Installing: {}", package));
         let start = std::time::Instant::now();
         match run_pip_install(
             &ctx.uv_path,
@@ -101,10 +99,7 @@ pub fn install_plugin(
             Ok(()) => {
                 logger::debug(&format!("pip install took: {:?}", start.elapsed()));
             }
-            Err(e) => {
-                logger::error(&format!("Failed to install: {}", package));
-                return Err(e);
-            }
+            Err(e) => return Err(e),
         }
 
         // uv pip install mutates site-packages and dist-info directories. Refresh the
@@ -222,45 +217,9 @@ fn run_pip_install(
 ) -> Result<(), PluginError> {
     let install_args = build_pip_install_args(python_path, package, editable, no_cache);
 
-    logger::debug(&format!("Running: {} {}", uv_path, install_args.join(" ")));
-
-    let output = Command::new(uv_path)
-        .args(&install_args)
-        .output()
-        .map_err(|e| {
-            logger::error(&format!("Failed to run pip install: {}", e));
-            PluginError::Io(e)
-        })?;
-
-    let command_for_log = format!("{} {}", uv_path, install_args.join(" "));
-    logger::capture_output_always(&command_for_log, &output);
-
-    if logger::get_verbosity() > 0 {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        if !stdout.trim().is_empty() {
-            print!("{stdout}");
-        }
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if !stderr.trim().is_empty() {
-            eprint!("{stderr}");
-        }
-    }
-
-    if !output.status.success() {
-        if logger::get_verbosity() == 0 {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            if !stderr.trim().is_empty() {
-                eprintln!("{stderr}");
-            }
-        }
-        logger::error(&format!("pip install failed for package '{}'", package));
-        return Err(PluginError::CommandFailed {
-            command: format!("{} pip install {}", uv_path, package),
-            status: output.status.code(),
-        });
-    }
-
-    Ok(())
+    uv::run(uv_path, "Installing", package, install_args)
+        .map(|_| ())
+        .map_err(PluginError::from)
 }
 
 fn build_pip_install_args(
@@ -275,7 +234,6 @@ fn build_pip_install_args(
         "--python".to_string(),
         python_path.to_string(),
         "--prerelease=allow".to_string(),
-        "--no-progress".to_string(),
     ];
 
     if no_cache {
@@ -293,26 +251,20 @@ fn build_pip_install_args(
 fn print_install_summary(pkg: &str, version: &str, count: usize, elapsed: std::time::Duration) {
     let elapsed_ms = elapsed.as_millis();
     if count == 0 {
-        println!(
-            "{}",
-            format!("No plugins found in {}ms", elapsed_ms)
-                .bold()
-                .dimmed()
-        );
+        logger::status(&format!(
+            "Installed {pkg} and registered 0 plugin(s) in {elapsed_ms}ms"
+        ));
         return;
     }
-    let disp = if version.is_empty() {
-        format!("{}", pkg.bold())
+
+    let package = if version.is_empty() {
+        pkg.to_string()
     } else {
-        format!("{}=={}", pkg.bold(), version)
+        format!("{pkg}=={version}")
     };
-    println!(
-        "{}",
-        format!("Installed {} plugin(s) in {}ms", count, elapsed_ms)
-            .bold()
-            .dimmed()
-    );
-    println!(" {} {}", "+".bold().green(), disp);
+    logger::status(&format!(
+        "Installed {package} and registered {count} plugin(s) in {elapsed_ms}ms"
+    ));
 }
 
 /// Check if a package is a workspace (by detecting [tool.uv.workspace] in pyproject.toml)
@@ -356,6 +308,10 @@ fn discover_all_installed_packages(
 
     if packages.is_empty() {
         logger::warn("No packages with r2x_plugin entry points found");
+        logger::status(&format!(
+            "Discovered 0 package(s) with 0 plugin(s) in {}ms",
+            total_start.elapsed().as_millis()
+        ));
         return Ok(());
     }
 
@@ -408,12 +364,12 @@ fn discover_all_installed_packages(
         ) {
             if entry_count > 0 {
                 let version_str = package_version.as_deref().unwrap_or("");
-                let disp = if version_str.is_empty() {
-                    format!("{}", package_name.bold())
+                let package = if version_str.is_empty() {
+                    package_name.clone()
                 } else {
-                    format!("{}=={}", package_name.bold(), version_str)
+                    format!("{package_name}=={version_str}")
                 };
-                println!(" {} {}", "+".bold().green(), disp);
+                logger::status(&format!("Discovered plugin package: {package}"));
                 discovered_count += 1;
                 total_entry_points += entry_count;
             }
@@ -423,15 +379,9 @@ fn discover_all_installed_packages(
     }
 
     let elapsed_ms = total_start.elapsed().as_millis();
-    println!(
-        "{}",
-        format!(
-            "Discovered {} package(s) with {} plugin(s) in {}ms",
-            discovered_count, total_entry_points, elapsed_ms
-        )
-        .bold()
-        .dimmed()
-    );
+    logger::status(&format!(
+        "Discovered {discovered_count} package(s) with {total_entry_points} plugin(s) in {elapsed_ms}ms"
+    ));
 
     Ok(())
 }
@@ -445,5 +395,6 @@ mod tests {
         let args = build_pip_install_args("/tmp/python", "/tmp/plugin", true, true);
         assert!(args.iter().any(|arg| arg == "-e"));
         assert!(args.iter().any(|arg| arg == "--no-cache"));
+        assert!(!args.iter().any(|arg| arg == "--no-progress"));
     }
 }

--- a/crates/r2x-cli/src/commands/plugins/remove.rs
+++ b/crates/r2x-cli/src/commands/plugins/remove.rs
@@ -1,6 +1,6 @@
 use crate::commands::plugins::context::PluginContext;
 use crate::plugins::error::PluginError;
-use colored::Colorize;
+use crate::uv;
 use r2x_logger as logger;
 use std::process::Command;
 
@@ -36,19 +36,11 @@ pub fn remove_plugin(package: &str, ctx: &mut PluginContext) -> Result<(), Plugi
         }
     }
 
-    println!(
-        "{}",
-        format!("Uninstalled {} plugin(s)", removed_plugin_count).dimmed()
-    );
-    println!(" {} {}", "-".bold().red(), package.bold());
-
+    logger::status(&format!(
+        "Uninstalled {removed_plugin_count} plugin(s): {package}"
+    ));
     for dep in &orphaned_dependencies {
-        println!(
-            " {} {} {}",
-            "-".bold().red(),
-            dep.bold(),
-            "(dependency)".dimmed()
-        );
+        logger::status(&format!("Uninstalled dependency: {dep}"));
     }
 
     Ok(())
@@ -67,29 +59,14 @@ fn is_package_installed(
 }
 
 fn uninstall_package(uv_path: &str, python_path: &str, package: &str) -> Result<(), PluginError> {
-    logger::debug(&format!(
-        "Running: {} pip uninstall --python {} {}",
-        uv_path, python_path, package
-    ));
-
-    let output = Command::new(uv_path)
-        .args(["pip", "uninstall", "--python", python_path, package])
-        .output()
-        .map_err(|e| {
-            logger::error(&format!("Failed to run pip uninstall: {}", e));
-            PluginError::Io(e)
-        })?;
-
-    logger::capture_output(&format!("uv pip uninstall {}", package), &output);
-
-    if !output.status.success() {
-        logger::error(&format!("pip uninstall failed for package '{}'", package));
-        return Err(PluginError::CommandFailed {
-            command: format!("{} pip uninstall {}", uv_path, package),
-            status: output.status.code(),
-        });
-    }
-
-    logger::info(&format!("Package '{}' uninstalled successfully", package));
-    Ok(())
+    let uninstall_args = vec![
+        "pip".to_string(),
+        "uninstall".to_string(),
+        "--python".to_string(),
+        python_path.to_string(),
+        package.to_string(),
+    ];
+    uv::run(uv_path, "Uninstalling", package, uninstall_args)
+        .map(|_| ())
+        .map_err(PluginError::from)
 }

--- a/crates/r2x-cli/src/commands/plugins/sync.rs
+++ b/crates/r2x-cli/src/commands/plugins/sync.rs
@@ -2,13 +2,13 @@ use crate::commands::plugins::context::PluginContext;
 use crate::commands::plugins::utils::short_commit;
 use crate::plugins::error::PluginError;
 use crate::plugins::package_spec::{build_package_spec, is_git_url};
-use colored::Colorize;
+use crate::uv;
 use r2x_ast::AstDiscovery;
 use r2x_logger as logger;
 use r2x_manifest::types::{InstallType, Package, PackageSource};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -64,7 +64,7 @@ pub fn sync_manifest(ctx: &mut PluginContext, upgrade: bool) -> Result<(), Plugi
     }
 
     let num_packages = packages_to_sync.len();
-    logger::step(&format!("Syncing {} package(s)...", num_packages));
+    logger::status(&format!("Syncing {num_packages} package(s)..."));
 
     // Partition packages into "unchanged" (skip AST) and "stale" (need rediscovery).
     //
@@ -203,14 +203,9 @@ pub fn sync_manifest(ctx: &mut PluginContext, upgrade: bool) -> Result<(), Plugi
     }
 
     let elapsed_ms = total_start.elapsed().as_millis();
-    println!(
-        "{}",
-        format!(
-            "Synced {} package(s), {} plugin(s) in {}ms",
-            synced_packages, total_plugins, elapsed_ms
-        )
-        .dimmed()
-    );
+    logger::status(&format!(
+        "Synced {synced_packages} package(s), {total_plugins} plugin(s) in {elapsed_ms}ms"
+    ));
 
     Ok(())
 }
@@ -310,11 +305,6 @@ fn upgrade_packages(
     targets.sort();
 
     let target_count = targets.len();
-    logger::step(&format!("Upgrading {} package(s)...", target_count));
-
-    for target in &targets {
-        logger::info(&format!("Upgrading: {}", target));
-    }
 
     // Batch all targets into a single uv pip install call.
     // Single resolution pass, parallel downloads, one install transaction.
@@ -470,42 +460,24 @@ fn run_upgrade_batch(
         .map(|t| build_package_spec(t, None, None, None, None))
         .collect::<Result<Vec<_>, _>>()?;
 
-    logger::debug(&format!(
-        "Running: {} pip install --upgrade --python {} {}",
+    let mut install_args = vec![
+        "pip".to_string(),
+        "install".to_string(),
+        "--python".to_string(),
+        python_path.to_string(),
+        "--upgrade".to_string(),
+        "--prerelease=allow".to_string(),
+    ];
+    install_args.extend(normalized.iter().cloned());
+
+    uv::run(
         uv_path,
-        python_path,
-        normalized.join(" ")
-    ));
-
-    let mut cmd = Command::new(uv_path);
-    cmd.args([
-        "pip",
-        "install",
-        "--python",
-        python_path,
-        "--upgrade",
-        "--prerelease=allow",
-        "--no-progress",
-    ]);
-    for target in &normalized {
-        cmd.arg(target.as_str());
-    }
-
-    let status = cmd
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()
-        .map_err(PluginError::Io)?;
-
-    if !status.success() {
-        return Err(PluginError::CommandFailed {
-            command: format!("{uv_path} pip install --upgrade {}", normalized.join(" ")),
-            status: status.code(),
-        });
-    }
-
-    Ok(())
+        "Upgrading",
+        &format!("{} package(s)", targets.len()),
+        install_args,
+    )
+    .map(|_| ())
+    .map_err(PluginError::from)
 }
 
 fn resolve_package_path(
@@ -592,12 +564,7 @@ fn print_upgrade_changes(
 
         if let Some(line) = change_line {
             changed += 1;
-            println!(
-                " {} {} {}",
-                "~".bold().yellow(),
-                package.name.bold(),
-                line.dimmed()
-            );
+            logger::status(&format!("Updated {}: {line}", package.name));
         }
     }
 

--- a/crates/r2x-cli/src/commands/read.rs
+++ b/crates/r2x-cli/src/commands/read.rs
@@ -1621,7 +1621,7 @@ fn ensure_module_installed(
         display_name
     ));
 
-    install_package_with_spinner(config, python_exe, package_spec, display_name)?;
+    install_package(config, python_exe, package_spec, display_name)?;
     Ok(())
 }
 
@@ -1636,48 +1636,29 @@ fn module_exists(python_exe: &str, module_name: &str) -> bool {
         .is_ok_and(|status| status.success())
 }
 
-fn install_package_with_spinner(
+fn install_package(
     config: &mut Config,
     python_exe: &str,
     package_spec: &str,
     display_name: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let uv_path = config.ensure_uv_path()?;
-    let mut install_cmd = Command::new(&uv_path);
-    install_cmd
-        .arg("pip")
-        .arg("install")
-        .arg("--python")
-        .arg(python_exe)
-        .arg("--no-progress")
-        .arg(package_spec);
+    let install_args = vec![
+        "pip".to_string(),
+        "install".to_string(),
+        "--python".to_string(),
+        python_exe.to_string(),
+        package_spec.to_string(),
+    ];
 
-    logger::debug(&format!("Running: {:?}", install_cmd));
-    // Print status without spinner since we need interactive terminal for SSH prompts
-    logger::info(&format!("Installing {} into venv...", display_name));
+    crate::uv::run(
+        &uv_path,
+        "Installing runtime dependency",
+        display_name,
+        install_args,
+    )?;
 
-    // Use inherited stdio to allow interactive prompts (e.g., SSH key passphrases)
-    let status = install_cmd
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()
-        .map_err(|e| {
-            logger::error(&format!("Failed to install {} into venv", display_name));
-            format!("Failed to run uv pip install: {}", e)
-        })?;
-
-    if !status.success() {
-        logger::error(&format!("Failed to install {} into venv", display_name));
-        return Err(format!(
-            "uv pip install {} failed: exit code {}",
-            package_spec,
-            status.code().unwrap_or(-1)
-        )
-        .into());
-    }
-
-    logger::success(&format!("Installed {} into venv", display_name));
+    logger::success(&format!("Installed {display_name} into venv"));
     Ok(())
 }
 

--- a/crates/r2x-cli/src/lib.rs
+++ b/crates/r2x-cli/src/lib.rs
@@ -11,6 +11,7 @@ pub mod manifest_lookup;
 pub mod package_verification;
 pub mod pipeline_config;
 pub mod plugins;
+mod uv;
 
 #[cfg(test)]
 pub(crate) mod test_support;

--- a/crates/r2x-cli/src/main.rs
+++ b/crates/r2x-cli/src/main.rs
@@ -229,6 +229,7 @@ fn main() {
     // Initialize logger with verbosity level, log_python flag, and no_stdout flag
     if let Err(e) = logger::init_with_config(
         cli.global.verbosity_level(),
+        cli.global.quiet,
         effective_log_python,
         effective_no_stdout,
         saved_log_path,

--- a/crates/r2x-cli/src/package_verification.rs
+++ b/crates/r2x-cli/src/package_verification.rs
@@ -7,7 +7,6 @@ use r2x_logger as logger;
 use r2x_manifest::types::{Manifest, Package, PackageSource};
 use r2x_python::utils::resolve_site_package_path;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum VerificationResult {
@@ -161,7 +160,6 @@ fn ensure_manifest_package(package: &Package, config: &Config) -> Result<(), Ver
     let python_exe = config.get_venv_python_path();
     let install_args = build_pip_install_args(&python_exe, &[package_spec], editable);
 
-    logger::info(&format!("Installing missing package: {}", package_spec));
     run_pip_install(config, &install_args, 1)
 }
 
@@ -200,7 +198,6 @@ fn build_pip_install_args(python_exe: &str, packages: &[&str], editable: bool) -
         "--python".to_string(),
         python_exe.to_string(),
         "--prerelease=allow".to_string(),
-        "--no-progress".to_string(),
     ];
 
     if editable {
@@ -221,29 +218,19 @@ fn run_pip_install(
         .as_ref()
         .ok_or_else(|| VerificationError::ReinstallFailed("uv not configured".to_string()))?;
 
-    let mut cmd = Command::new(uv_path);
-    cmd.args(install_args);
-
-    logger::debug(&format!("Running: {:?}", cmd));
-
-    // Use inherited stdio to allow interactive prompts (e.g., SSH key passphrases)
-    let status = cmd
-        .stdin(Stdio::inherit())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .status()
-        .map_err(|e| VerificationError::ReinstallFailed(format!("Failed to execute uv: {}", e)))?;
-
-    if !status.success() {
-        return Err(VerificationError::ReinstallFailed(format!(
-            "uv pip install failed: exit code {}",
-            status.code().unwrap_or(-1)
-        )));
-    }
+    let package_target = install_args
+        .last()
+        .map_or("requested packages", String::as_str);
+    crate::uv::run(
+        uv_path,
+        "Installing missing package",
+        package_target,
+        install_args.to_vec(),
+    )
+    .map_err(|error| VerificationError::ReinstallFailed(error.to_string()))?;
 
     logger::success(&format!(
-        "Successfully installed {} packages",
-        package_count
+        "Successfully installed {package_count} package(s)"
     ));
     Ok(())
 }

--- a/crates/r2x-cli/src/plugins/error.rs
+++ b/crates/r2x-cli/src/plugins/error.rs
@@ -1,3 +1,5 @@
+use crate::uv::UvCommandError;
+use r2x_logger as logger;
 use thiserror::Error;
 
 use r2x_manifest::errors::ManifestError;
@@ -31,6 +33,37 @@ pub enum PluginError {
         status: Option<i32>,
     },
 
+    #[error(
+        "uv command failed during {phase} for '{target}' after {elapsed_ms}ms (exit {status:?}): {reason}. Command: {command}. See log: {log_path}"
+    )]
+    UvCommandFailed {
+        phase: String,
+        target: String,
+        command: String,
+        status: Option<i32>,
+        elapsed_ms: u128,
+        reason: String,
+        log_path: String,
+    },
+
     #[error("Invalid arguments: {0}")]
     InvalidArgs(String),
+}
+
+impl From<UvCommandError> for PluginError {
+    fn from(error: UvCommandError) -> Self {
+        Self::UvCommandFailed {
+            phase: error.phase,
+            target: error.target,
+            command: error.command,
+            status: error.status,
+            elapsed_ms: error.elapsed.as_millis(),
+            reason: error.reason,
+            log_path: if error.log_path.is_empty() {
+                logger::get_log_path_string()
+            } else {
+                error.log_path
+            },
+        }
+    }
 }

--- a/crates/r2x-cli/src/uv.rs
+++ b/crates/r2x-cli/src/uv.rs
@@ -131,10 +131,7 @@ fn flush_logged_lines(
     stream: &str,
     flush_partial: bool,
 ) {
-    loop {
-        let Some(newline) = pending.iter().position(|byte| *byte == b'\n') else {
-            break;
-        };
+    while let Some(newline) = pending.iter().position(|byte| *byte == b'\n') {
         let line: Vec<u8> = pending.drain(..=newline).collect();
         logger::record_command_output(phase, target, stream, &line);
     }

--- a/crates/r2x-cli/src/uv.rs
+++ b/crates/r2x-cli/src/uv.rs
@@ -1,0 +1,571 @@
+//! Shared subprocess policy for uv operations.
+//!
+//! uv writes progress to stderr when it has a terminal. The runner keeps that
+//! stderr attached to the user's terminal, forwards uv output to stderr so CLI
+//! data output remains available for future machine-readable commands, and
+//! adds explicit non-interactive options when animation is not appropriate.
+
+use r2x_logger as logger;
+use std::env;
+use std::io::{self, IsTerminal, Read, Write};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OutputMode {
+    Interactive,
+    Linear,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct OutputPolicy {
+    mode: OutputMode,
+    disable_color: bool,
+}
+
+#[derive(Debug)]
+pub(crate) struct UvCommandError {
+    pub(crate) phase: String,
+    pub(crate) target: String,
+    pub(crate) command: String,
+    pub(crate) status: Option<i32>,
+    pub(crate) elapsed: Duration,
+    pub(crate) reason: String,
+    pub(crate) log_path: String,
+}
+
+impl std::fmt::Display for UvCommandError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "uv command failed during {} for '{}' after {}ms (exit {:?}): {}. Command: {}. See log: {}",
+            self.phase,
+            self.target,
+            self.elapsed.as_millis(),
+            self.status,
+            self.reason,
+            self.command,
+            self.log_path
+        )
+    }
+}
+
+impl std::error::Error for UvCommandError {}
+
+fn output_policy(
+    stdout_is_terminal: bool,
+    stderr_is_terminal: bool,
+    no_color: bool,
+    term_dumb: bool,
+    ci: bool,
+) -> OutputPolicy {
+    let interactive = stdout_is_terminal && stderr_is_terminal && !no_color && !term_dumb && !ci;
+    OutputPolicy {
+        mode: if interactive {
+            OutputMode::Interactive
+        } else {
+            OutputMode::Linear
+        },
+        disable_color: no_color || term_dumb || ci,
+    }
+}
+
+fn current_output_policy() -> OutputPolicy {
+    output_policy(
+        io::stdout().is_terminal(),
+        io::stderr().is_terminal(),
+        env::var_os("NO_COLOR").is_some(),
+        env::var("TERM").ok().as_deref() == Some("dumb"),
+        env::var_os("CI").is_some(),
+    )
+}
+
+fn build_command_args(
+    operation_args: &[String],
+    policy: OutputPolicy,
+    quiet: u8,
+    verbose: u8,
+) -> Vec<String> {
+    let mut args = Vec::with_capacity(operation_args.len() + 5);
+
+    for _ in 0..quiet {
+        args.push("--quiet".to_string());
+    }
+    if quiet == 0 {
+        for _ in 0..verbose {
+            args.push("--verbose".to_string());
+        }
+    }
+
+    if policy.mode == OutputMode::Linear || quiet > 0 {
+        args.push("--no-progress".to_string());
+    }
+    if policy.disable_color {
+        args.push("--color".to_string());
+        args.push("never".to_string());
+    }
+
+    args.extend(operation_args.iter().cloned());
+    args
+}
+
+fn forward_stream<R: Read, W: Write>(mut source: R, mut destination: W) -> io::Result<()> {
+    let mut buffer = [0_u8; 8192];
+    loop {
+        let bytes_read = source.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        destination.write_all(&buffer[..bytes_read])?;
+        destination.flush()?;
+    }
+    Ok(())
+}
+
+fn flush_logged_lines(
+    pending: &mut Vec<u8>,
+    phase: &str,
+    target: &str,
+    stream: &str,
+    flush_partial: bool,
+) {
+    loop {
+        let Some(newline) = pending.iter().position(|byte| *byte == b'\n') else {
+            break;
+        };
+        let line: Vec<u8> = pending.drain(..=newline).collect();
+        logger::record_command_output(phase, target, stream, &line);
+    }
+
+    if flush_partial && !pending.is_empty() {
+        logger::record_command_output(phase, target, stream, pending);
+        pending.clear();
+    }
+}
+
+fn forward_logged_stream<R: Read, W: Write>(
+    mut source: R,
+    mut destination: W,
+    phase: &str,
+    target: &str,
+    stream: &str,
+) -> io::Result<()> {
+    let mut buffer = [0_u8; 8192];
+    let mut pending = Vec::new();
+    loop {
+        let bytes_read = source.read(&mut buffer)?;
+        if bytes_read == 0 {
+            flush_logged_lines(&mut pending, phase, target, stream, true);
+            break;
+        }
+        destination.write_all(&buffer[..bytes_read])?;
+        destination.flush()?;
+        pending.extend_from_slice(&buffer[..bytes_read]);
+        flush_logged_lines(&mut pending, phase, target, stream, false);
+    }
+    Ok(())
+}
+
+fn is_sensitive_option(argument: &str) -> bool {
+    let name = argument
+        .trim_start_matches('-')
+        .split('=')
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .replace('_', "-");
+    matches!(
+        name.as_str(),
+        "access-token"
+            | "refresh-token"
+            | "token"
+            | "password"
+            | "passwd"
+            | "secret"
+            | "api-key"
+            | "apikey"
+            | "private-key"
+    )
+}
+
+#[cfg(unix)]
+fn configure_command(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+
+    command.process_group(0);
+}
+
+#[cfg(windows)]
+fn configure_command(command: &mut Command) {
+    use std::os::windows::process::CommandExt;
+
+    // CREATE_NEW_PROCESS_GROUP; taskkill /T below handles descendants.
+    command.creation_flags(0x0000_0200);
+}
+
+#[cfg(not(any(unix, windows)))]
+fn configure_command(_command: &mut Command) {}
+
+fn terminate_process_tree(child: &mut std::process::Child) {
+    #[cfg(unix)]
+    {
+        let process_group = format!("-{}", child.id());
+        let _ = Command::new("kill")
+            .args(["-KILL", &process_group])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+
+    #[cfg(windows)]
+    {
+        let process_id = child.id().to_string();
+        let _ = Command::new("taskkill")
+            .args(["/PID", &process_id, "/T", "/F"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+
+    let _ = child.kill();
+}
+
+fn append_command_argument(command: &mut String, argument: &str) {
+    command.push(' ');
+    if argument
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || "./_:@=-[]".contains(character))
+    {
+        command.push_str(argument);
+    } else {
+        command.push_str(&format!("{argument:?}"));
+    }
+}
+
+fn format_command(uv_path: &str, args: &[String]) -> String {
+    let mut command = uv_path.to_string();
+    let mut index = 0;
+    while let Some(argument) = args.get(index) {
+        let argument = logger::redact_sensitive_text(argument);
+        if is_sensitive_option(&argument) && !argument.contains('=') && index + 1 < args.len() {
+            append_command_argument(&mut command, &format!("{argument} [REDACTED]"));
+            index += 2;
+        } else {
+            append_command_argument(&mut command, &argument);
+            index += 1;
+        }
+    }
+    command
+}
+
+/// Run one uv operation with inherited stdin and streamed output.
+///
+/// uv's stderr remains inherited in an interactive terminal so it can render
+/// its own progress. In linear mode both streams are drained concurrently,
+/// forwarded to stderr, and copied to the sanitized r2x log.
+pub(crate) fn run(
+    uv_path: &str,
+    phase: &str,
+    target: &str,
+    operation_args: Vec<String>,
+) -> Result<Duration, UvCommandError> {
+    let target = logger::redact_sensitive_text(target);
+    let policy = current_output_policy();
+    let args = build_command_args(
+        &operation_args,
+        policy,
+        logger::get_quiet_level(),
+        logger::get_verbosity(),
+    );
+    let command_display = format_command(uv_path, &args);
+    let log_path = logger::get_log_path_string();
+    let start = Instant::now();
+
+    logger::status(&format!("{phase}: {target}"));
+    logger::record_command(phase, &target, &command_display, None, Duration::ZERO);
+
+    let mut command = Command::new(uv_path);
+    let capture_output = policy.mode == OutputMode::Linear;
+    command
+        .args(&args)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::piped())
+        .stderr(if capture_output {
+            Stdio::piped()
+        } else {
+            Stdio::inherit()
+        });
+    configure_command(&mut command);
+
+    let mut child = command.spawn().map_err(|error| UvCommandError {
+        phase: phase.to_string(),
+        target: target.clone(),
+        command: command_display.clone(),
+        status: None,
+        elapsed: start.elapsed(),
+        reason: format!("failed to start uv: {error}"),
+        log_path: log_path.clone(),
+    })?;
+
+    let Some(stdout) = child.stdout.take() else {
+        terminate_process_tree(&mut child);
+        let _ = child.wait();
+        return Err(UvCommandError {
+            phase: phase.to_string(),
+            target: target.clone(),
+            command: command_display.clone(),
+            status: None,
+            elapsed: start.elapsed(),
+            reason: "uv stdout was not available for streaming".to_string(),
+            log_path: log_path.clone(),
+        });
+    };
+
+    let (forward_error_sender, forward_error_receiver) = mpsc::channel();
+    let phase_for_stdout = phase.to_string();
+    let target_for_stdout = target.clone();
+    let stdout_error_sender = forward_error_sender.clone();
+    let stdout_forwarder = thread::spawn(move || {
+        let result = if capture_output {
+            forward_logged_stream(
+                stdout,
+                io::stderr(),
+                &phase_for_stdout,
+                &target_for_stdout,
+                "stdout",
+            )
+        } else {
+            forward_stream(stdout, io::stderr())
+        };
+        if let Err(error) = &result {
+            let _ = stdout_error_sender.send(io::Error::new(error.kind(), error.to_string()));
+        }
+        result
+    });
+
+    let stderr_forwarder = if capture_output {
+        let Some(stderr) = child.stderr.take() else {
+            terminate_process_tree(&mut child);
+            let _ = child.wait();
+            let _ = stdout_forwarder.join();
+            return Err(UvCommandError {
+                phase: phase.to_string(),
+                target: target.clone(),
+                command: command_display,
+                status: None,
+                elapsed: start.elapsed(),
+                reason: "uv stderr was not available for streaming".to_string(),
+                log_path,
+            });
+        };
+        let phase_for_stderr = phase.to_string();
+        let target_for_stderr = target.clone();
+        let stderr_error_sender = forward_error_sender;
+        Some(thread::spawn(move || {
+            let result = forward_logged_stream(
+                stderr,
+                io::stderr(),
+                &phase_for_stderr,
+                &target_for_stderr,
+                "stderr",
+            );
+            if let Err(error) = &result {
+                let _ = stderr_error_sender.send(io::Error::new(error.kind(), error.to_string()));
+            }
+            result
+        }))
+    } else {
+        drop(forward_error_sender);
+        None
+    };
+
+    let (process_status, wait_error, forwarding_error) = loop {
+        if let Ok(error) = forward_error_receiver.try_recv() {
+            terminate_process_tree(&mut child);
+            break (child.wait().ok(), None, Some(error));
+        }
+
+        match child.try_wait() {
+            Ok(Some(status)) => break (Some(status), None, None),
+            Ok(None) => thread::sleep(Duration::from_millis(10)),
+            Err(error) => {
+                terminate_process_tree(&mut child);
+                break (child.wait().ok(), Some(error), None);
+            }
+        }
+    };
+
+    let elapsed = start.elapsed();
+    let forwarding_error = forwarding_error.or_else(|| forward_error_receiver.try_recv().ok());
+    let stdout_result = if forwarding_error.is_some() {
+        None
+    } else {
+        Some(match stdout_forwarder.join() {
+            Ok(result) => result,
+            Err(_) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "uv stdout forwarding thread panicked",
+            )),
+        })
+    };
+    let stderr_result = if forwarding_error.is_some() {
+        None
+    } else {
+        stderr_forwarder.map(|forwarder| match forwarder.join() {
+            Ok(result) => result,
+            Err(_) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "uv stderr forwarding thread panicked",
+            )),
+        })
+    };
+
+    let status = process_status.ok_or_else(|| UvCommandError {
+        phase: phase.to_string(),
+        target: target.clone(),
+        command: command_display.clone(),
+        status: None,
+        elapsed,
+        reason: format!(
+            "failed while waiting for uv: {}",
+            wait_error.map_or_else(
+                || "the process did not report an exit status".to_string(),
+                |error| error.to_string()
+            )
+        ),
+        log_path: log_path.clone(),
+    })?;
+    let exit_code = status.code();
+    logger::record_command(phase, &target, &command_display, exit_code, elapsed);
+
+    let forwarding_error = forwarding_error
+        .or_else(|| stdout_result.and_then(Result::err))
+        .or_else(|| stderr_result.and_then(Result::err));
+    if let Some(error) = forwarding_error {
+        return Err(UvCommandError {
+            phase: phase.to_string(),
+            target: target.clone(),
+            command: command_display,
+            status: exit_code,
+            elapsed,
+            reason: format!("failed to forward uv output: {error}"),
+            log_path,
+        });
+    }
+
+    if !status.success() {
+        return Err(UvCommandError {
+            phase: phase.to_string(),
+            target: target.clone(),
+            command: command_display,
+            status: exit_code,
+            elapsed,
+            reason: "process exited unsuccessfully".to_string(),
+            log_path,
+        });
+    }
+
+    Ok(elapsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_command_args, format_command, forward_stream, output_policy, OutputMode, OutputPolicy,
+    };
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[test]
+    fn streamed_stdout_is_forwarded_without_buffering() {
+        let mut destination = Vec::new();
+        let result = forward_stream("uv output\n".as_bytes(), &mut destination);
+        assert!(result.is_ok());
+        assert_eq!(destination, b"uv output\n");
+    }
+
+    #[test]
+    fn interactive_mode_keeps_uv_progress_enabled() {
+        let policy = output_policy(true, true, false, false, false);
+        assert_eq!(policy.mode, OutputMode::Interactive);
+        assert_eq!(
+            build_command_args(&args(&["pip", "install"]), policy, 0, 0),
+            args(&["pip", "install"])
+        );
+    }
+
+    #[test]
+    fn pipes_and_ci_use_linear_no_progress_output() {
+        for policy in [
+            output_policy(false, true, false, false, false),
+            output_policy(true, false, false, false, false),
+            output_policy(true, true, false, false, true),
+            output_policy(true, true, false, true, false),
+        ] {
+            assert_eq!(policy.mode, OutputMode::Linear);
+            let command = build_command_args(&args(&["pip", "install"]), policy, 0, 0);
+            assert!(command.contains(&"--no-progress".to_string()));
+        }
+    }
+
+    #[test]
+    fn quiet_and_verbose_levels_are_forwarded_to_uv() {
+        let interactive = OutputPolicy {
+            mode: OutputMode::Interactive,
+            disable_color: false,
+        };
+        assert_eq!(
+            build_command_args(&args(&["pip"]), interactive, 2, 0),
+            args(&["--quiet", "--quiet", "--no-progress", "pip"])
+        );
+        assert_eq!(
+            build_command_args(&args(&["pip"]), interactive, 0, 2),
+            args(&["--verbose", "--verbose", "pip"])
+        );
+    }
+
+    #[test]
+    fn command_display_redacts_credentials() {
+        let command = format_command(
+            "uv",
+            &args(&["pip", "https://user:password@example.com/pkg?token=secret"]),
+        );
+        assert!(!command.contains("password@example.com"));
+        assert!(!command.contains("token=secret"));
+        assert!(command.contains("[REDACTED]"));
+
+        let option_command = format_command("uv", &args(&["--token", "secret"]));
+        assert!(!option_command.contains("secret"));
+        let underscored_option = format_command("uv", &args(&["--api_key", "secret"]));
+        assert!(!underscored_option.contains("secret"));
+    }
+
+    #[test]
+    fn no_color_disables_uv_color() {
+        let policy = output_policy(true, true, true, false, false);
+        assert_eq!(
+            build_command_args(&args(&["pip"]), policy, 0, 0),
+            args(&["--no-progress", "--color", "never", "pip"])
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_subprocess_reports_phase_target_and_exit_status() {
+        let error = match super::run("false", "Installing", "demo", Vec::new()) {
+            Ok(_) => return,
+            Err(error) => error,
+        };
+
+        assert_eq!(error.phase, "Installing");
+        assert_eq!(error.target, "demo");
+        assert_eq!(error.status, Some(1));
+        assert!(error.elapsed < std::time::Duration::from_secs(5));
+    }
+}

--- a/crates/r2x-logger/src/lib.rs
+++ b/crates/r2x-logger/src/lib.rs
@@ -8,6 +8,7 @@ use std::sync::Mutex;
 
 static LOG_FILE: Mutex<Option<PathBuf>> = Mutex::new(None);
 static VERBOSITY: Mutex<u8> = Mutex::new(0);
+static QUIET: Mutex<u8> = Mutex::new(0);
 static LOG_PYTHON: Mutex<bool> = Mutex::new(false);
 static NO_STDOUT: Mutex<bool> = Mutex::new(false);
 static FILE_LOG_LEVEL: Mutex<LogLevel> = Mutex::new(LogLevel::Info);
@@ -27,6 +28,11 @@ enum LogLevel {
 /// Get the current verbosity level for use by other modules (e.g., Python bridge)
 pub fn get_verbosity() -> u8 {
     VERBOSITY.lock().ok().map_or(0, |v| *v)
+}
+
+/// Get the number of quiet flags supplied by the user.
+pub fn get_quiet_level() -> u8 {
+    QUIET.lock().ok().map_or(0, |v| *v)
 }
 
 /// Get whether Python logging to console is enabled
@@ -63,6 +69,7 @@ pub fn set_current_plugin(plugin_name: Option<String>) {
 /// Initialize logger with optional path override, file level, and max file size.
 pub fn init_with_config(
     verbosity: u8,
+    quiet: u8,
     log_python: bool,
     no_stdout: bool,
     log_path: Option<&str>,
@@ -71,6 +78,10 @@ pub fn init_with_config(
     // Set verbosity level
     if let Ok(mut v) = VERBOSITY.lock() {
         *v = verbosity;
+    }
+
+    if let Ok(mut q) = QUIET.lock() {
+        *q = quiet;
     }
 
     // Set log_python flag
@@ -150,7 +161,16 @@ fn write_to_log_with_source(level: LogLevel, message: &str, source: &str) {
     if level > allowed_level {
         return;
     }
+    write_log_line(message, source);
+}
 
+/// Write a subprocess transcript regardless of the configured log level.
+fn write_to_log_unfiltered(message: &str) {
+    write_log_line(message, "RUST");
+}
+
+fn write_log_line(message: &str, source: &str) {
+    let message = redact_sensitive_text(&sanitize_log_message(message));
     if let Ok(log_file_guard) = LOG_FILE.lock() {
         if let Some(ref log_path) = *log_file_guard {
             let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
@@ -162,6 +182,181 @@ fn write_to_log_with_source(level: LogLevel, message: &str, source: &str) {
             }
         }
     }
+}
+
+/// Redact credentials from command summaries and persisted log messages.
+pub fn redact_sensitive_text(message: &str) -> String {
+    let mut redacted = redact_url_userinfo(message);
+    for key in [
+        "access_token",
+        "refresh_token",
+        "token",
+        "password",
+        "passwd",
+        "secret",
+        "api_key",
+        "api-key",
+        "apikey",
+        "private_key",
+        "private-key",
+    ] {
+        redacted = redact_key_value(&redacted, key);
+    }
+    redacted
+}
+
+fn redact_url_userinfo(message: &str) -> String {
+    let mut result = String::with_capacity(message.len());
+    let mut cursor = 0;
+
+    while let Some(relative_scheme_end) = message[cursor..].find("://") {
+        let scheme_end = cursor + relative_scheme_end;
+        let authority_start = scheme_end + 3;
+        let authority_end = message[authority_start..]
+            .find(|character: char| {
+                character.is_whitespace() || matches!(character, '/' | '?' | '#' | ')' | ']')
+            })
+            .map_or(message.len(), |offset| authority_start + offset);
+        let authority = &message[authority_start..authority_end];
+
+        let Some(userinfo_end) = authority.find('@') else {
+            result.push_str(&message[cursor..authority_end]);
+            cursor = authority_end;
+            continue;
+        };
+        let userinfo = &authority[..userinfo_end];
+        if userinfo == "git" {
+            result.push_str(&message[cursor..authority_end]);
+        } else {
+            result.push_str(&message[cursor..authority_start]);
+            result.push_str("[REDACTED]@");
+            result.push_str(&authority[userinfo_end + 1..]);
+        }
+        cursor = authority_end;
+    }
+
+    result.push_str(&message[cursor..]);
+    result
+}
+
+fn redact_key_value(message: &str, key: &str) -> String {
+    let lower_message = message.to_ascii_lowercase();
+    let mut result = String::with_capacity(message.len());
+    let mut cursor = 0;
+
+    while let Some(relative_key_start) = lower_message[cursor..].find(key) {
+        let key_start = cursor + relative_key_start;
+        let key_end = key_start + key.len();
+        let boundary_before = key_start == 0
+            || !message[..key_start]
+                .chars()
+                .next_back()
+                .is_some_and(|character| character.is_ascii_alphanumeric() || character == '_');
+        let boundary_after = key_end == message.len()
+            || !message[key_end..]
+                .chars()
+                .next()
+                .is_some_and(|character| character.is_ascii_alphanumeric() || character == '_');
+
+        if !boundary_before || !boundary_after {
+            result.push_str(&message[cursor..key_end]);
+            cursor = key_end;
+            continue;
+        }
+
+        let key_syntax_end = if message[key_end..].starts_with('"') {
+            key_end + 1
+        } else {
+            key_end
+        };
+        let separator_start = message[key_syntax_end..]
+            .find(|character: char| !character.is_ascii_whitespace())
+            .map_or(message.len(), |offset| key_syntax_end + offset);
+        let has_separator = separator_start < message.len()
+            && matches!(message.as_bytes()[separator_start], b'=' | b':');
+        let is_option = message[..key_start].ends_with("--");
+        if !has_separator && !is_option {
+            result.push_str(&message[cursor..key_end]);
+            cursor = key_end;
+            continue;
+        }
+
+        let value_start = if has_separator {
+            message[separator_start + 1..]
+                .find(|character: char| !character.is_ascii_whitespace())
+                .map_or(message.len(), |offset| separator_start + 1 + offset)
+        } else {
+            separator_start
+        };
+        if value_start == message.len() {
+            result.push_str(&message[cursor..key_end]);
+            cursor = key_end;
+            continue;
+        }
+
+        let quoted = matches!(message.as_bytes()[value_start], b'"' | b'\'');
+        let (value_content_start, value_end, closing_quote) = if quoted {
+            let quote = message.as_bytes()[value_start];
+            let content_start = value_start + 1;
+            let content_end = message[content_start..]
+                .find(|character: char| character as u8 == quote)
+                .map_or(message.len(), |offset| content_start + offset);
+            (
+                content_start,
+                content_end,
+                (content_end < message.len()).then_some(quote),
+            )
+        } else {
+            let content_end = message[value_start..]
+                .find(|character: char| {
+                    character.is_whitespace()
+                        || matches!(character, '&' | ',' | ')' | ']' | '"' | '\'')
+                })
+                .map_or(message.len(), |offset| value_start + offset);
+            (value_start, content_end, None)
+        };
+
+        result.push_str(&message[cursor..value_content_start]);
+        if value_content_start < value_end {
+            result.push_str("[REDACTED]");
+        }
+        if let Some(quote) = closing_quote {
+            result.push(quote as char);
+            cursor = value_end + 1;
+        } else {
+            cursor = value_end;
+        }
+    }
+
+    result.push_str(&message[cursor..]);
+    result
+}
+
+fn sanitize_log_message(message: &str) -> String {
+    let mut sanitized = String::with_capacity(message.len());
+    let mut chars = message.chars().peekable();
+
+    while let Some(character) = chars.next() {
+        if character == '\u{1b}' {
+            // Drop ANSI CSI sequences, including carriage movement and color.
+            if chars.peek() == Some(&'[') {
+                chars.next();
+                for sequence_character in chars.by_ref() {
+                    if ('@'..='~').contains(&sequence_character) {
+                        break;
+                    }
+                }
+            }
+            continue;
+        }
+
+        if character == '\r' || (character.is_control() && character != '\n' && character != '\t') {
+            continue;
+        }
+        sanitized.push(character);
+    }
+
+    sanitized
 }
 
 fn maybe_rotate_log_file(log_path: &PathBuf, incoming_bytes: u64) {
@@ -195,6 +390,47 @@ pub fn info(message: &str) {
     if get_verbosity() >= 1 {
         eprintln!("{}", message);
     }
+}
+
+/// Emit a user-facing status line on stderr unless quiet output was requested.
+///
+/// Status lines are deliberately separate from [`info`]: normal commands need
+/// to show progress, while informational diagnostics remain controlled by
+/// `-v`.
+pub fn status(message: &str) {
+    let safe_message = redact_sensitive_text(&sanitize_log_message(message));
+    write_to_log(LogLevel::Info, &format!("STATUS {}", safe_message));
+    if get_quiet_level() == 0 {
+        eprintln!("{}", safe_message);
+    }
+}
+
+/// Record a subprocess invocation without copying interactive terminal output into the log.
+pub fn record_command(
+    phase: &str,
+    target: &str,
+    command: &str,
+    status: Option<i32>,
+    elapsed: std::time::Duration,
+) {
+    write_to_log(
+        LogLevel::Info,
+        &format!(
+            "COMMAND phase={phase:?} target={target:?} command={command:?} exit={status:?} elapsed_ms={}",
+            elapsed.as_millis()
+        ),
+    );
+}
+
+/// Record a non-interactive subprocess output chunk after sanitizing it for the log.
+pub fn record_command_output(phase: &str, target: &str, stream: &str, output: &[u8]) {
+    let output = String::from_utf8_lossy(output);
+    if output.is_empty() {
+        return;
+    }
+    write_to_log_unfiltered(&format!(
+        "COMMAND_OUTPUT phase={phase:?} target={target:?} stream={stream:?}:\n{output}"
+    ));
 }
 
 /// Log a debug message (to console if verbose >= 1, always to file)
@@ -236,8 +472,10 @@ pub fn error(message: &str) {
 /// Log a success message (to console only for user feedback)
 pub fn success(message: &str) {
     write_to_log(LogLevel::Info, &format!("SUCCESS {}", message));
-    let check = "\u{2714}".green().bold(); // 🗸 HEAVY CHECK MARK
-    eprintln!("{} {}", check, message);
+    if get_quiet_level() == 0 {
+        let check = "\u{2714}".green().bold(); // 🗸 HEAVY CHECK MARK
+        eprintln!("{} {}", check, message);
+    }
 }
 
 /// Log a step message (important user-facing step)
@@ -354,8 +592,10 @@ pub fn spinner_success(message: &str) {
             spinner.finish_and_clear();
         }
     }
-    // Show success message with checkmark
-    eprintln!("{} {}", "✔".green().bold(), message);
+    // Show success message with checkmark unless quiet output was requested
+    if get_quiet_level() == 0 {
+        eprintln!("{} {}", "✔".green().bold(), message);
+    }
 }
 
 /// Stop the spinner with an error message
@@ -400,6 +640,74 @@ mod tests {
         });
 
         assert!(!called.get());
+    }
+
+    #[test]
+    fn sanitize_log_message_removes_terminal_control_sequences() {
+        assert_eq!(
+            sanitize_log_message("\u{1b}[2K\r\u{1b}[32mready\u{1b}[0m"),
+            "ready"
+        );
+    }
+
+    #[test]
+    fn redact_sensitive_text_removes_url_and_key_value_credentials() {
+        let message = "git+https://user:secret@example.com/pkg?token=abc123";
+        assert_eq!(
+            redact_sensitive_text(message),
+            "git+https://[REDACTED]@example.com/pkg?token=[REDACTED]"
+        );
+        assert_eq!(
+            redact_sensitive_text("git@github.com:org/repo.git"),
+            "git@github.com:org/repo.git"
+        );
+        assert_eq!(
+            redact_sensitive_text(r#"{"token": "abc"} --token secret"#),
+            r#"{"token": "[REDACTED]"} --token [REDACTED]"#
+        );
+        assert_eq!(
+            redact_sensitive_text("--api-key=secret --private-key secret"),
+            "--api-key=[REDACTED] --private-key [REDACTED]"
+        );
+    }
+
+    #[test]
+    fn command_output_is_logged_even_when_file_level_is_error() {
+        let Ok(_guard) = TEST_LOCK.lock() else {
+            return;
+        };
+        let log_path = std::env::temp_dir().join(format!(
+            "r2x-logger-test-{}-{}.log",
+            std::process::id(),
+            "command-output"
+        ));
+        let path_string = log_path.to_string_lossy().to_string();
+        if init_with_config(0, 0, false, false, Some(&path_string), None).is_err() {
+            return;
+        }
+        if let Ok(mut file_level) = FILE_LOG_LEVEL.lock() {
+            *file_level = LogLevel::Error;
+        }
+
+        record_command_output(
+            "Installing",
+            "demo",
+            "stderr",
+            b"\x1b[2K\rpassword=secret\n",
+        );
+
+        let contents = match fs::read_to_string(&log_path) {
+            Ok(contents) => contents,
+            Err(_) => return,
+        };
+        assert!(contents.contains("COMMAND_OUTPUT"));
+        assert!(contents.contains("password=[REDACTED]"));
+        assert!(!contents.contains('\u{1b}'));
+        let _ = fs::remove_file(log_path);
+
+        if let Ok(mut file_level) = FILE_LOG_LEVEL.lock() {
+            *file_level = LogLevel::Info;
+        }
     }
 
     #[test]

--- a/crates/r2x-logger/src/lib.rs
+++ b/crates/r2x-logger/src/lib.rs
@@ -486,55 +486,6 @@ pub fn step(message: &str) {
     write_to_log(LogLevel::Info, &format!("STEP: {}", message));
 }
 
-/// Capture command output and log it
-pub fn capture_output(command_name: &str, output: &std::process::Output) {
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    write_to_log(
-        LogLevel::Debug,
-        &format!(
-            "COMMAND: {} (exit code: {:?})",
-            command_name,
-            output.status.code()
-        ),
-    );
-
-    if !stdout.is_empty() {
-        write_to_log(LogLevel::Debug, &format!("  STDOUT:\n{}", stdout));
-    }
-
-    if !stderr.is_empty() {
-        write_to_log(LogLevel::Debug, &format!("  STDERR:\n{}", stderr));
-    }
-}
-
-/// Capture command output and always persist it to log file at info level.
-///
-/// This is useful for noisy subprocesses where console output is suppressed
-/// by default but full output should remain available in logs.
-pub fn capture_output_always(command_name: &str, output: &std::process::Output) {
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    write_to_log(
-        LogLevel::Info,
-        &format!(
-            "COMMAND: {} (exit code: {:?})",
-            command_name,
-            output.status.code()
-        ),
-    );
-
-    if !stdout.is_empty() {
-        write_to_log(LogLevel::Info, &format!("  STDOUT:\n{}", stdout));
-    }
-
-    if !stderr.is_empty() {
-        write_to_log(LogLevel::Info, &format!("  STDERR:\n{}", stderr));
-    }
-}
-
 /// Get the log file path for display
 pub fn get_log_path() -> Option<PathBuf> {
     LOG_FILE.lock().ok().and_then(|guard| guard.clone())


### PR DESCRIPTION
## Summary

- Stream UV subprocess output through a shared runner with TTY-aware progress behavior.
- Preserve stdin for Git/SSH authentication and keep status/diagnostics on stderr.
- Apply the same behavior to plugin install, sync upgrades, cleanup, and automatic reinstalls.
- Add actionable failures, install timing/plugin counts, log sanitization, and output-focused tests/documentation.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features`
- `git diff --check`

Closes #170
